### PR TITLE
Defining a serving signature with inference specific parsing_fn

### DIFF
--- a/python/ml4ir/config/keys.py
+++ b/python/ml4ir/config/keys.py
@@ -106,6 +106,10 @@ class ExecutionModeKey(Key):
     INFERENCE_EVALUATE = "inference_evaluate"
     TRAIN_INFERENCE_EVALUATE = "train_inference_evaluate"
     TRAIN_INFERENCE = "train_inference"
+    INFERENCE_RESAVE = "inference_resave"
+    EVALUATE_RESAVE = "evaluate_resave"
+    INFERENCE_EVALUATE_RESAVE = "inference_evaluate_resave"
+    RESAVE_ONLY = "resave_only"
 
 
 class ServingSignatureKey(Key):

--- a/python/ml4ir/config/parse_args.py
+++ b/python/ml4ir/config/parse_args.py
@@ -223,6 +223,13 @@ def define_args() -> ArgumentParser:
         "If that is not the case, then you can still use a SavedModel from a model_file for inference/evaluation only",
     )
 
+    parser.add_argument(
+        "--pad_records_at_inference",
+        type=bool,
+        default=False,
+        help="Whether to pad records at inference time. Used to define the TFRecord serving signature in the SavedModel",
+    )
+
     return parser
 
 

--- a/python/ml4ir/config/parse_args.py
+++ b/python/ml4ir/config/parse_args.py
@@ -214,6 +214,13 @@ def define_args() -> ArgumentParser:
         help="Gradient clipping value/threshold for the optimizer.",
     )
 
+    parser.add_argument(
+        "--compile_keras_model",
+        type=bool,
+        default=False,
+        help="Whether to compile a loaded SavedModel into a Keras model. NOTE: This requires ",
+    )
+
     return parser
 
 

--- a/python/ml4ir/config/parse_args.py
+++ b/python/ml4ir/config/parse_args.py
@@ -218,7 +218,9 @@ def define_args() -> ArgumentParser:
         "--compile_keras_model",
         type=bool,
         default=False,
-        help="Whether to compile a loaded SavedModel into a Keras model. NOTE: This requires ",
+        help="Whether to compile a loaded SavedModel into a Keras model. "
+        "NOTE: This requires that the SavedModel's architecture, loss, metrics, etc are the same as the RankingModel"
+        "If that is not the case, then you can still use a SavedModel from a model_file for inference/evaluation only",
     )
 
     return parser

--- a/python/ml4ir/data/tfrecord_helper.py
+++ b/python/ml4ir/data/tfrecord_helper.py
@@ -1,0 +1,64 @@
+from tensorflow import train
+import tensorflow as tf
+from ml4ir.config.keys import TFRecordTypeKey
+
+
+def _bytes_feature(values):
+    """Returns a bytes_list from a string / byte."""
+    values = [value.encode("utf-8") for value in values]
+    return train.Feature(bytes_list=train.BytesList(value=values))
+
+
+def _float_feature(values):
+    """Returns a float_list from a float / double."""
+    return train.Feature(float_list=train.FloatList(value=values))
+
+
+def _int64_feature(values):
+    """Returns an int64_list from a bool / enum / int / uint."""
+    return train.Feature(int64_list=train.Int64List(value=values))
+
+
+def _get_feature_fn(dtype):
+    """Returns appropriate feature function based on datatype"""
+    if dtype == tf.string:
+        return _bytes_feature
+    elif dtype == tf.float32:
+        return _float_feature
+    elif dtype == tf.int64:
+        return _int64_feature
+    else:
+        raise Exception("Feature dtype {} not supported".format(dtype))
+
+
+def get_sequence_example_proto(group, context_features, sequence_features):
+    """
+    Get a sequence example protobuf from a dataframe group
+
+    Args:
+        - group: pandas dataframe group
+        - context_features: feature configuration for context
+        - sequence_features: feature configuration for sequence
+    """
+    sequence_features_dict = dict()
+    context_features_dict = dict()
+
+    for feature_info in context_features:
+        feature_name = feature_info["name"]
+        feature_fn = _get_feature_fn(feature_info["dtype"])
+        context_features_dict[feature_name] = feature_fn([group[feature_name].tolist()[0]])
+
+    for feature_info in sequence_features:
+        feature_name = feature_info["name"]
+        feature_fn = _get_feature_fn(feature_info["dtype"])
+        if feature_info["tfrecord_type"] == TFRecordTypeKey.SEQUENCE:
+            sequence_features_dict[feature_name] = train.FeatureList(
+                feature=[feature_fn(group[feature_name].tolist())]
+            )
+
+    sequence_example_proto = train.SequenceExample(
+        context=train.Features(feature=context_features_dict),
+        feature_lists=train.FeatureLists(feature_list=sequence_features_dict),
+    )
+
+    return sequence_example_proto

--- a/python/ml4ir/data/tfrecord_reader.py
+++ b/python/ml4ir/data/tfrecord_reader.py
@@ -114,45 +114,6 @@ def make_parse_fn(
             feature_tensor = sequence_features.get(feature_node_name, default_tensor)
 
             if isinstance(feature_tensor, sparse.SparseTensor):
-                if feature_node_name == feature_config.get_rank(key="node_name"):
-                    # Add mask for identifying padded records
-                    mask = tf.ones_like(sparse.to_dense(sparse.reset_shape(feature_tensor)))
-                    mask = tf.expand_dims(mask, axis=2)
-
-                    def crop_fn():
-                        tf.print(
-                            "\n[WARN] Bad query found. Number of records : ", tf.shape(mask)[1]
-                        )
-                        return image.crop_to_bounding_box(
-                            mask,
-                            offset_height=0,
-                            offset_width=0,
-                            target_height=1,
-                            target_width=max_num_records,
-                        )
-
-                    mask = tf.cond(
-                        tf.shape(mask)[1] < max_num_records,
-                        # Pad if there are missing records
-                        lambda: image.pad_to_bounding_box(
-                            mask,
-                            offset_height=0,
-                            offset_width=0,
-                            target_height=1,
-                            target_width=max_num_records,
-                        ),
-                        # Crop if there are extra records
-                        crop_fn,
-                    )
-                    mask = tf.squeeze(mask)
-
-                    # Check validity of mask
-                    tf.debugging.assert_greater(
-                        tf.cast(tf.reduce_sum(mask), tf.float32), tf.constant(0.0)
-                    )
-
-                    features_dict["mask"] = mask
-
                 feature_tensor = sparse.reset_shape(feature_tensor, new_shape=[1, max_num_records])
                 feature_tensor = sparse.to_dense(feature_tensor)
                 feature_tensor = tf.squeeze(feature_tensor)
@@ -165,24 +126,67 @@ def make_parse_fn(
 
             features_dict[feature_node_name] = feature_tensor
 
-        """
-        Define dummy mask if the rank field is not a required field for serving
-
-        NOTE:
-        This masks all max_num_records as 1 as there is no real way to know
-        the number of records in the query. There is no predefined required field,
-        and hence we would need to do a full pass of all features to find the record shape.
-        This approach might be unstable if different features have different shapes.
-
-        Hence we just mask all records
-
-        TODO: Might be beneficial to define one mandatory required sequence feature,
-        such as record_key and use that to define the mask. Alternatively, we could
-        make rank a mandatory required feature, but a dummy value would have to be
-        passed to rank at inference time.
-        """
+        # Define mask to identify padded records
         if required_only and not feature_config.get_rank("serving_info")["required"]:
+            """
+            Define dummy mask if the rank field is not a required field for serving
+
+            NOTE:
+            This masks all max_num_records as 1 as there is no real way to know
+            the number of records in the query. There is no predefined required field,
+            and hence we would need to do a full pass of all features to find the record shape.
+            This approach might be unstable if different features have different shapes.
+
+            Hence we just mask all records
+
+            TODO: Might be beneficial to define a mandatory required sequence feature,
+            such as record_key and use that to define the mask. Alternatively, we could
+            make rank a mandatory required feature, but a dummy value would have to be
+            passed to rank at inference time.
+            """
             features_dict["mask"] = tf.constant(value=1, shape=[max_num_records], dtype=tf.int64)
+            features_dict["num_records"] = tf.constant(max_num_records, dtype=tf.int64)
+        else:
+            # Typically used at training time, to pad/clip to a fixed number of records per query
+
+            # Use rank as a reference tensor to infer shape/num_records in query
+            reference_tensor = sequence_features.get(feature_config.get_rank(key="node_name"))
+
+            # Add mask for identifying padded records
+            mask = tf.ones_like(sparse.to_dense(sparse.reset_shape(reference_tensor)))
+            mask = tf.expand_dims(mask, axis=2)
+
+            def crop_fn():
+                tf.print("\n[WARN] Bad query found. Number of records : ", tf.shape(mask)[1])
+                return image.crop_to_bounding_box(
+                    mask,
+                    offset_height=0,
+                    offset_width=0,
+                    target_height=1,
+                    target_width=max_num_records,
+                )
+
+            mask = tf.cond(
+                tf.shape(mask)[1] < max_num_records,
+                # Pad if there are missing records
+                lambda: image.pad_to_bounding_box(
+                    mask,
+                    offset_height=0,
+                    offset_width=0,
+                    target_height=1,
+                    target_width=max_num_records,
+                ),
+                # Crop if there are extra records
+                crop_fn,
+            )
+            mask = tf.squeeze(mask)
+            num_records = tf.cast(tf.reduce_sum(mask), tf.int64)
+
+            # Check validity of mask
+            tf.debugging.assert_greater(num_records, tf.constant(0, dtype=tf.int64))
+
+            features_dict["mask"] = mask
+            features_dict["num_records"] = tf.reduce_sum(mask)
 
         labels = features_dict.pop(feature_config.get_label(key="name"))
 

--- a/python/ml4ir/data/tfrecord_reader.py
+++ b/python/ml4ir/data/tfrecord_reader.py
@@ -31,7 +31,7 @@ def make_parse_fn(
     feature_config: FeatureConfig,
     max_num_records: int = 25,
     required_only: bool = False,
-    pad_records: bool = False,
+    pad_records: bool = True,
 ) -> tf.function:
     """
     Create a parse function using the context and sequence features spec

--- a/python/ml4ir/data/tfrecord_reader.py
+++ b/python/ml4ir/data/tfrecord_reader.py
@@ -113,7 +113,9 @@ def make_parse_fn(
 
             Hence we just mask all records
             """
-            features_dict["mask"] = tf.constant(value=1, shape=[max_num_records], dtype=tf.int64)
+            features_dict["mask"] = tf.constant(
+                value=1, shape=[max_num_records], dtype=feature_config.get_rank("dtype")
+            )
             num_records = tf.constant(max_num_records, dtype=tf.int64)
         else:
             # Typically used at training time, to pad/clip to a fixed number of records per query
@@ -182,11 +184,9 @@ def make_parse_fn(
                 feature_tensor = sparse.to_dense(feature_tensor)
                 feature_tensor = tf.squeeze(feature_tensor)
 
-                # If feature is a string, then decode into numbers
-                if feature_layer_info["type"] == FeatureTypeKey.STRING:
-                    feature_tensor = preprocessing.preprocess_text(
-                        feature_tensor, preprocessing_info
-                    )
+            # If feature is a string, then decode into numbers
+            if feature_layer_info["type"] == FeatureTypeKey.STRING:
+                feature_tensor = preprocessing.preprocess_text(feature_tensor, preprocessing_info)
 
             features_dict[feature_node_name] = feature_tensor
 

--- a/python/ml4ir/data/tfrecord_reader.py
+++ b/python/ml4ir/data/tfrecord_reader.py
@@ -9,7 +9,6 @@ from ml4ir.features import preprocessing
 from ml4ir.features.feature_config import FeatureConfig
 from ml4ir.config.keys import TFRecordTypeKey, FeatureTypeKey
 
-from typing import Optional
 
 """
 This module contains helper methods for reading and writing
@@ -30,8 +29,9 @@ def _get_default_value(dtype, serving_info):
 
 def make_parse_fn(
     feature_config: FeatureConfig,
-    max_num_records: Optional[int] = None,
+    max_num_records: int = 25,
     required_only: bool = False,
+    pad_records: bool = False,
 ) -> tf.function:
     """
     Create a parse function using the context and sequence features spec
@@ -39,8 +39,8 @@ def make_parse_fn(
     Args:
         feature_config: FeatureConfig object defining context and sequence features
         max_num_records: Maximum number of records per query. Used for padding.
-                         If set to None, does NOT pad records.
         required_only: Whether to only use required fields from the feature_config
+        pad_records: Whether to pad records
     """
 
     context_features_spec = dict()
@@ -100,32 +100,6 @@ def make_parse_fn(
 
             features_dict[feature_node_name] = feature_tensor
 
-        # Pad sequence features to max_num_records
-        for feature_info in feature_config.get_sequence_features():
-            feature_node_name = feature_info.get("node_name", feature_info["name"])
-            feature_layer_info = feature_info["feature_layer_info"]
-            preprocessing_info = feature_info.get("preprocessing_info", {})
-
-            default_tensor = tf.constant(
-                value=_get_default_value(feature_info["dtype"], feature_info.get("serving_info")),
-                dtype=feature_info["dtype"],
-                shape=[max_num_records],
-            )
-            feature_tensor = sequence_features.get(feature_node_name, default_tensor)
-
-            if isinstance(feature_tensor, sparse.SparseTensor):
-                feature_tensor = sparse.reset_shape(feature_tensor, new_shape=[1, max_num_records])
-                feature_tensor = sparse.to_dense(feature_tensor)
-                feature_tensor = tf.squeeze(feature_tensor)
-
-                # If feature is a string, then decode into numbers
-                if feature_layer_info["type"] == FeatureTypeKey.STRING:
-                    feature_tensor = preprocessing.preprocess_text(
-                        feature_tensor, preprocessing_info
-                    )
-
-            features_dict[feature_node_name] = feature_tensor
-
         # Define mask to identify padded records
         if required_only and not feature_config.get_rank("serving_info")["required"]:
             """
@@ -138,14 +112,9 @@ def make_parse_fn(
             This approach might be unstable if different features have different shapes.
 
             Hence we just mask all records
-
-            TODO: Might be beneficial to define a mandatory required sequence feature,
-            such as record_key and use that to define the mask. Alternatively, we could
-            make rank a mandatory required feature, but a dummy value would have to be
-            passed to rank at inference time.
             """
             features_dict["mask"] = tf.constant(value=1, shape=[max_num_records], dtype=tf.int64)
-            features_dict["num_records"] = tf.constant(max_num_records, dtype=tf.int64)
+            num_records = tf.constant(max_num_records, dtype=tf.int64)
         else:
             # Typically used at training time, to pad/clip to a fixed number of records per query
 
@@ -155,6 +124,7 @@ def make_parse_fn(
             # Add mask for identifying padded records
             mask = tf.ones_like(sparse.to_dense(sparse.reset_shape(reference_tensor)))
             mask = tf.expand_dims(mask, axis=2)
+            num_records = tf.cast(tf.reduce_sum(mask), tf.int64)
 
             def crop_fn():
                 tf.print("\n[WARN] Bad query found. Number of records : ", tf.shape(mask)[1])
@@ -166,27 +136,59 @@ def make_parse_fn(
                     target_width=max_num_records,
                 )
 
-            mask = tf.cond(
-                tf.shape(mask)[1] < max_num_records,
-                # Pad if there are missing records
-                lambda: image.pad_to_bounding_box(
-                    mask,
-                    offset_height=0,
-                    offset_width=0,
-                    target_height=1,
-                    target_width=max_num_records,
-                ),
-                # Crop if there are extra records
-                crop_fn,
-            )
+            if pad_records:
+                mask = tf.cond(
+                    tf.shape(mask)[1] < max_num_records,
+                    # Pad if there are missing records
+                    lambda: image.pad_to_bounding_box(
+                        mask,
+                        offset_height=0,
+                        offset_width=0,
+                        target_height=1,
+                        target_width=max_num_records,
+                    ),
+                    # Crop if there are extra records
+                    crop_fn,
+                )
             mask = tf.squeeze(mask)
-            num_records = tf.cast(tf.reduce_sum(mask), tf.int64)
 
             # Check validity of mask
             tf.debugging.assert_greater(num_records, tf.constant(0, dtype=tf.int64))
 
             features_dict["mask"] = mask
-            features_dict["num_records"] = tf.reduce_sum(mask)
+            num_records = max_num_records if pad_records else num_records
+
+        # Pad sequence features to max_num_records
+        for feature_info in feature_config.get_sequence_features():
+            feature_node_name = feature_info.get("node_name", feature_info["name"])
+            feature_layer_info = feature_info["feature_layer_info"]
+            preprocessing_info = feature_info.get("preprocessing_info", {})
+
+            default_tensor = tf.fill(
+                value=tf.constant(
+                    value=_get_default_value(
+                        feature_info["dtype"], feature_info.get("serving_info")
+                    ),
+                    dtype=feature_info["dtype"],
+                ),
+                dims=[max_num_records if pad_records else num_records],
+            )
+            feature_tensor = sequence_features.get(feature_node_name, default_tensor)
+
+            if isinstance(feature_tensor, sparse.SparseTensor):
+                feature_tensor = sparse.reset_shape(
+                    feature_tensor, new_shape=[1, max_num_records if pad_records else num_records]
+                )
+                feature_tensor = sparse.to_dense(feature_tensor)
+                feature_tensor = tf.squeeze(feature_tensor)
+
+                # If feature is a string, then decode into numbers
+                if feature_layer_info["type"] == FeatureTypeKey.STRING:
+                    feature_tensor = preprocessing.preprocess_text(
+                        feature_tensor, preprocessing_info
+                    )
+
+            features_dict[feature_node_name] = feature_tensor
 
         labels = features_dict.pop(feature_config.get_label(key="name"))
 

--- a/python/ml4ir/data/tfrecord_writer.py
+++ b/python/ml4ir/data/tfrecord_writer.py
@@ -5,12 +5,12 @@ from ml4ir.io import file_io
 from typing import List
 from logging import Logger
 from ml4ir.features.feature_config import FeatureConfig, parse_config
-from ml4ir.config.keys import TFRecordTypeKey
 from argparse import ArgumentParser
 import glob
 import os
 import sys
 from ml4ir.io.logging_utils import setup_logging
+from ml4ir.data.tfrecord_helper import get_sequence_example_proto
 
 
 """
@@ -36,65 +36,6 @@ python ml4ir/data/tfrecord_writer.py \
 --convert_single_files True
 
 """
-
-
-def _bytes_feature(values):
-    """Returns a bytes_list from a string / byte."""
-    values = [value.encode("utf-8") for value in values]
-    return train.Feature(bytes_list=train.BytesList(value=values))
-
-
-def _float_feature(values):
-    """Returns a float_list from a float / double."""
-    return train.Feature(float_list=train.FloatList(value=values))
-
-
-def _int64_feature(values):
-    """Returns an int64_list from a bool / enum / int / uint."""
-    return train.Feature(int64_list=train.Int64List(value=values))
-
-
-def _get_feature_fn(dtype):
-    """Returns appropriate feature function based on datatype"""
-    if dtype == tf.string:
-        return _bytes_feature
-    elif dtype == tf.float32:
-        return _float_feature
-    elif dtype == tf.int64:
-        return _int64_feature
-    else:
-        raise Exception("Feature dtype {} not supported".format(dtype))
-
-
-def _get_sequence_example_proto(group, feature_config: FeatureConfig):
-    """
-    Get a sequence example protobuf from a dataframe group
-
-    Args:
-        - group: pandas dataframe group
-    """
-    sequence_features_dict = dict()
-    context_features_dict = dict()
-
-    for feature_info in feature_config.get_context_features():
-        feature_name = feature_info["name"]
-        feature_fn = _get_feature_fn(feature_info["dtype"])
-        context_features_dict[feature_name] = feature_fn([group[feature_name].tolist()[0]])
-
-    for feature_info in feature_config.get_sequence_features():
-        feature_name = feature_info["name"]
-        feature_fn = _get_feature_fn(feature_info["dtype"])
-        if feature_info["tfrecord_type"] == TFRecordTypeKey.SEQUENCE:
-            sequence_features_dict[feature_name] = train.FeatureList(
-                feature=[feature_fn(group[feature_name].tolist())]
-            )
-
-    sequence_example_proto = train.SequenceExample(
-        context=train.Features(feature=context_features_dict),
-        feature_lists=train.FeatureLists(feature_list=sequence_features_dict),
-    )
-
-    return sequence_example_proto
 
 
 def write(
@@ -123,7 +64,11 @@ def write(
     with io.TFRecordWriter(tfrecord_file) as tf_writer:
         context_feature_names = feature_config.get_context_features(key="name")
         sequence_example_protos = df.groupby(context_feature_names).apply(
-            lambda g: _get_sequence_example_proto(group=g, feature_config=feature_config)
+            lambda g: get_sequence_example_proto(
+                group=g,
+                context_features=feature_config.get_context_features(),
+                sequence_features=feature_config.get_sequence_features(),
+            )
         )
         for sequence_example_proto in sequence_example_protos:
             tf_writer.write(sequence_example_proto.SerializeToString())

--- a/python/ml4ir/features/feature_config.py
+++ b/python/ml4ir/features/feature_config.py
@@ -266,10 +266,12 @@ class FeatureConfig:
         def get_shape(feature_info: dict):
             feature_layer_info = feature_info["feature_layer_info"]
             preprocessing_info = feature_info.get("preprocessing_info", {})
+
+            # Setting size to None for sequence features as the num_records is variable
+            num_records = None
             if feature_info["tfrecord_type"] == TFRecordTypeKey.CONTEXT:
                 num_records = 1
-            else:
-                num_records = max_num_records
+
             if feature_layer_info["type"] == FeatureTypeKey.NUMERIC:
                 return (num_records,)
             elif feature_layer_info["type"] == FeatureTypeKey.STRING:
@@ -286,6 +288,9 @@ class FeatureConfig:
             node_name = feature_info.get("node_name", feature_info["name"])
             shape = get_shape(feature_info)
             inputs[node_name] = Input(shape=shape, name=node_name)
+
+        # Define input node that stores number of records in a query
+        inputs["num_records"] = Input(shape=(1,), name="num_records")
 
         return inputs
 

--- a/python/ml4ir/features/feature_config.py
+++ b/python/ml4ir/features/feature_config.py
@@ -304,7 +304,7 @@ class FeatureConfig:
         return {
             "name": "mask",
             "trainable": False,
-            "dtype": "int64",
+            "dtype": self.get_rank("dtype"),
             "feature_layer_info": {"type": FeatureTypeKey.NUMERIC, "shape": None},
             "serving_info": {"name": "mask", "required": False},
             "tfrecord_type": TFRecordTypeKey.SEQUENCE,

--- a/python/ml4ir/features/feature_config.py
+++ b/python/ml4ir/features/feature_config.py
@@ -285,8 +285,9 @@ class FeatureConfig:
             preprocessing_info = feature_info.get("preprocessing_info", {})
 
             # Setting size to None for sequence features as the num_records is variable
-            num_records = None
-            if feature_info["tfrecord_type"] == TFRecordTypeKey.CONTEXT:
+            if feature_info["tfrecord_type"] == TFRecordTypeKey.SEQUENCE:
+                num_records = None
+            else:
                 num_records = 1
 
             if feature_layer_info["type"] == FeatureTypeKey.NUMERIC:
@@ -307,9 +308,6 @@ class FeatureConfig:
                 shape=get_shape(feature_info), name=node_name, dtype=self.get_dtype(feature_info)
             )
 
-        # # Define input node that stores number of records in a query
-        # inputs["num_records"] = Input(shape=(1,), name="num_records", dtype=tf.int32)
-
         return inputs
 
     def generate_mask(self):
@@ -325,6 +323,10 @@ class FeatureConfig:
 
     def create_dummy_sequence_example(self, num_records=1, required_only=False):
         """Create a SequenceExample protobuffer with dummy values"""
+        """
+        TODO: The method should also be able to create a SequenceExample from
+        an input dictionary of feature values
+        """
         context_features = [
             f
             for f in self.get_context_features()

--- a/python/ml4ir/features/feature_layer.py
+++ b/python/ml4ir/features/feature_layer.py
@@ -59,7 +59,7 @@ def define_feature_layer(feature_config: FeatureConfig, max_num_records: int):
                 dense_feature = inputs[feature_node_name]
 
                 if feature_info["tfrecord_type"] == TFRecordTypeKey.CONTEXT:
-                    dense_feature = tf.tile(dense_feature, numeric_tile_shape)
+                    dense_feature = tf.tile(dense_feature, numeric_tile_shape, name="broooo")
 
                 if feature_info["trainable"]:
                     dense_feature = tf.expand_dims(tf.cast(dense_feature, tf.float32), axis=-1)

--- a/python/ml4ir/features/feature_layer.py
+++ b/python/ml4ir/features/feature_layer.py
@@ -11,7 +11,7 @@ def get_sequence_encoding(input, feature_info):
 
     input_feature = tf.cast(input, tf.uint8)
     input_feature = tf.reshape(input_feature, [-1, preprocessing_info["max_length"]])
-    if feature_layer_info["embedding_size"]:
+    if "embedding_size" in feature_layer_info:
         char_embedding = layers.Embedding(
             input_dim=256,
             output_dim=feature_layer_info["embedding_size"],

--- a/python/ml4ir/features/feature_layer.py
+++ b/python/ml4ir/features/feature_layer.py
@@ -28,8 +28,6 @@ def get_sequence_encoding(input, feature_info):
     if feature_info["tfrecord_type"] == TFRecordTypeKey.CONTEXT:
         # If feature is a context feature then tile it for all records
         encoding = tf.expand_dims(encoding, axis=1)
-        # encoding = tf.tile(encoding,
-        #                    tf.concat([tf.constant([1]), num_records, tf.constant([1])], axis=0))
     else:
         # If sequence feature, then reshape back to original shape
         # FIXME

--- a/python/ml4ir/model/pipeline.py
+++ b/python/ml4ir/model/pipeline.py
@@ -268,7 +268,9 @@ class RankingPipeline(object):
                 ExecutionModeKey.RESAVE_ONLY,
             }:
                 # Save model
-                model.save(models_dir=self.models_dir)
+                model.save(
+                    models_dir=self.models_dir, pad_records=self.args.pad_records_at_inference
+                )
 
             # Finish
             self.finish()

--- a/python/ml4ir/model/pipeline.py
+++ b/python/ml4ir/model/pipeline.py
@@ -202,6 +202,7 @@ class RankingPipeline(object):
                 learning_rate_decay_steps=self.args.learning_rate_decay_steps,
                 gradient_clip_value=self.args.gradient_clip_value,
                 compute_intermediate_stats=self.args.compute_intermediate_stats,
+                compile_keras_model=self.args.compile_keras_model,
                 logger=self.logger,
             )
             self.logger.info("Ranking Model created")
@@ -221,14 +222,13 @@ class RankingPipeline(object):
                     logging_frequency=self.args.logging_frequency,
                 )
 
-                # Save model
-                model.save(models_dir=self.models_dir)
-
             if self.args.execution_mode in {
                 ExecutionModeKey.TRAIN_INFERENCE_EVALUATE,
                 ExecutionModeKey.TRAIN_EVALUATE,
                 ExecutionModeKey.EVALUATE_ONLY,
                 ExecutionModeKey.INFERENCE_EVALUATE,
+                ExecutionModeKey.INFERENCE_EVALUATE_RESAVE,
+                ExecutionModeKey.EVALUATE_RESAVE,
             }:
                 # Evaluate
                 model.evaluate(
@@ -244,6 +244,8 @@ class RankingPipeline(object):
                 ExecutionModeKey.TRAIN_INFERENCE,
                 ExecutionModeKey.INFERENCE_EVALUATE,
                 ExecutionModeKey.INFERENCE_ONLY,
+                ExecutionModeKey.INFERENCE_EVALUATE_RESAVE,
+                ExecutionModeKey.INFERENCE_RESAVE,
             }:
                 # Predict ranking scores
                 model.predict(
@@ -252,6 +254,21 @@ class RankingPipeline(object):
                     logs_dir=self.logs_dir,
                     logging_frequency=self.args.logging_frequency,
                 )
+
+            # Save model
+            # NOTE: Model will be saved with the latest serving signatures
+            if self.args.execution_mode in {
+                ExecutionModeKey.TRAIN_INFERENCE_EVALUATE,
+                ExecutionModeKey.TRAIN_EVALUATE,
+                ExecutionModeKey.TRAIN_INFERENCE,
+                ExecutionModeKey.TRAIN_ONLY,
+                ExecutionModeKey.INFERENCE_EVALUATE_RESAVE,
+                ExecutionModeKey.EVALUATE_RESAVE,
+                ExecutionModeKey.INFERENCE_RESAVE,
+                ExecutionModeKey.RESAVE_ONLY,
+            }:
+                # Save model
+                model.save(models_dir=self.models_dir)
 
             # Finish
             self.finish()

--- a/python/ml4ir/model/pipeline.py
+++ b/python/ml4ir/model/pipeline.py
@@ -188,7 +188,7 @@ class RankingPipeline(object):
             self.logger.info("Ranking Dataset created")
 
             # Build model
-            model = RankingModel(
+            ranking_model = RankingModel(
                 model_config=self.model_config,
                 loss_key=self.loss,
                 scoring_key=self.scoring,
@@ -214,7 +214,7 @@ class RankingPipeline(object):
                 ExecutionModeKey.TRAIN_ONLY,
             }:
                 # Train
-                model.fit(
+                ranking_model.fit(
                     dataset=ranking_dataset,
                     num_epochs=self.args.num_epochs,
                     models_dir=self.models_dir,
@@ -231,7 +231,7 @@ class RankingPipeline(object):
                 ExecutionModeKey.EVALUATE_RESAVE,
             }:
                 # Evaluate
-                model.evaluate(
+                ranking_model.evaluate(
                     test_dataset=ranking_dataset.test,
                     inference_signature=self.args.inference_signature,
                     logging_frequency=self.args.logging_frequency,
@@ -248,7 +248,7 @@ class RankingPipeline(object):
                 ExecutionModeKey.INFERENCE_RESAVE,
             }:
                 # Predict ranking scores
-                model.predict(
+                ranking_model.predict(
                     test_dataset=ranking_dataset.test,
                     inference_signature=self.args.inference_signature,
                     logs_dir=self.logs_dir,
@@ -268,7 +268,7 @@ class RankingPipeline(object):
                 ExecutionModeKey.RESAVE_ONLY,
             }:
                 # Save model
-                model.save(
+                ranking_model.save(
                     models_dir=self.models_dir, pad_records=self.args.pad_records_at_inference
                 )
 

--- a/python/ml4ir/model/ranking_model.py
+++ b/python/ml4ir/model/ranking_model.py
@@ -404,7 +404,10 @@ class RankingModel:
         def _filter_records(x, mask):
             """Filter records that were padded in each query"""
             return tf.squeeze(
-                tf.gather_nd(x, tf.where(tf.not_equal(mask, tf.constant(0, dtype="int64"))))
+                tf.gather_nd(
+                    x,
+                    tf.where(tf.not_equal(tf.cast(mask, tf.int64), tf.constant(0, dtype="int64"))),
+                )
             )
 
         @tf.function

--- a/python/ml4ir/model/ranking_model.py
+++ b/python/ml4ir/model/ranking_model.py
@@ -500,7 +500,9 @@ class RankingModel:
         saved_model.save(
             self.model,
             export_dir=os.path.join(model_file, "tfrecord"),
-            signatures=define_serving_signatures(self.model, self.feature_config, pad_records),
+            signatures=define_serving_signatures(
+                self.model, self.feature_config, pad_records, self.max_num_records
+            ),
         )
         self.logger.info("Final model saved to : {}".format(model_file))
 

--- a/python/ml4ir/model/ranking_model.py
+++ b/python/ml4ir/model/ranking_model.py
@@ -95,7 +95,7 @@ class RankingModel:
             Individual input nodes are defined for each feature
             Each data point represents features for all records in a single query
             """
-            inputs: Dict[str, Input] = feature_config.define_inputs(max_num_records)
+            inputs: Dict[str, Input] = feature_config.define_inputs()
             self.model = self.build_model(inputs, optimizer, loss, metrics)
 
             if model_file:
@@ -403,11 +403,13 @@ class RankingModel:
         @tf.function
         def _filter_records(x, mask):
             """Filter records that were padded in each query"""
-            return tf.squeeze(tf.gather_nd(x, tf.where(tf.not_equal(mask, tf.constant(0.0)))))
+            return tf.squeeze(
+                tf.gather_nd(x, tf.where(tf.not_equal(mask, tf.constant(0, dtype="int64"))))
+            )
 
         @tf.function
         def _predict_score(features, label):
-            features = {k: tf.cast(v, tf.float32) for k, v in features.items()}
+            # features = {k: tf.cast(v, tf.float32) for k, v in features.items()}
             if self.is_compiled:
                 scores = infer(features)["ranking_scores"]
             else:

--- a/python/ml4ir/model/ranking_model.py
+++ b/python/ml4ir/model/ranking_model.py
@@ -547,7 +547,7 @@ class RankingModel:
         model = tf.keras.models.load_model(model_file, compile=False)
 
         self.logger.info("Successfully loaded SavedModel from {}".format(model_file))
-        self.logger.warning("Retraining is not supported. Model is loaded with compile=False")
+        self.logger.warning("Retraining is not yet supported. Model is loaded with compile=False")
 
         return model
 
@@ -557,6 +557,7 @@ class RankingModel:
 
         # Set weights of Keras model from the loaded model weights
         self.model.set_weights(loaded_model.get_weights())
+        self.logger.info("Weights have been set from SavedModel. RankingModel can now be trained.")
 
     def _build_callback_hooks(
         self, models_dir: str, logs_dir: str, is_training=True, logging_frequency=25

--- a/python/ml4ir/model/ranking_model.py
+++ b/python/ml4ir/model/ranking_model.py
@@ -475,7 +475,7 @@ class RankingModel:
 
         return pd.DataFrame(predictions_dict)
 
-    def save(self, models_dir: str):
+    def save(self, models_dir: str, pad_records: bool):
         """
         Save tf.keras model to models_dir
 
@@ -497,7 +497,7 @@ class RankingModel:
         saved_model.save(
             self.model,
             export_dir=os.path.join(model_file, "tfrecord"),
-            signatures=define_serving_signatures(self.model, self.feature_config),
+            signatures=define_serving_signatures(self.model, self.feature_config, pad_records),
         )
         self.logger.info("Final model saved to : {}".format(model_file))
 

--- a/python/ml4ir/model/serving.py
+++ b/python/ml4ir/model/serving.py
@@ -36,7 +36,9 @@ def define_tfrecord_signature(model, feature_config):
 
     # TFRecord Signature
     # Define a parsing function for tfrecord protos
-    inputs = feature_config.get_all_features(key="node_name", include_label=False)
+    inputs = feature_config.get_all_features(key="node_name", include_label=False) + [
+        "num_records"
+    ]
     tfrecord_parse_fn = make_parse_fn(
         feature_config=feature_config, max_num_records=25, required_only=True
     )

--- a/python/ml4ir/model/serving.py
+++ b/python/ml4ir/model/serving.py
@@ -1,0 +1,101 @@
+import tensorflow as tf
+from tensorflow import TensorSpec, TensorArray
+from ml4ir.config.keys import ServingSignatureKey
+from ml4ir.data.tfrecord_reader import make_parse_fn
+
+
+def define_default_signature(model, feature_config):
+    # Default signature
+    #
+    # TODO: Define input_signature
+    #
+    # @tf.function(input_signature=[])
+    # def _serve_default(**features):
+    #     features_dict = {k: tf.cast(v, tf.float32) for k, v in features.items()}
+    #     # Run the model to get predictions
+    #     predictions = model(inputs=features_dict)
+
+    #     # Mask the padded records
+    #     for key, value in predictions.items():
+    #         predictions[key] = tf.where(
+    #             tf.equal(features_dict['mask'], 0),
+    #             tf.constant(-np.inf),
+    #             predictions[key])
+
+    #     return predictions
+    return
+
+
+def define_tfrecord_signature(model, feature_config):
+    """
+    Add signatures to the tf keras savedmodel
+
+    Returns:
+        Serving signature function that accepts a TFRecord string tensor and returns predictions
+    """
+
+    # TFRecord Signature
+    # Define a parsing function for tfrecord protos
+    inputs = feature_config.get_all_features(key="node_name", include_label=False)
+    tfrecord_parse_fn = make_parse_fn(
+        feature_config=feature_config, max_num_records=25, required_only=True
+    )
+
+    # Define a serving signature for tfrecord
+    @tf.function(input_signature=[TensorSpec(shape=[None], dtype=tf.string)])
+    def _serve_tfrecord(sequence_example_protos):
+        input_size = tf.shape(sequence_example_protos)[0]
+        features_dict = {
+            feature: TensorArray(dtype=tf.float32, size=input_size) for feature in inputs
+        }
+
+        # Define loop index
+        i = tf.constant(0)
+
+        # Define loop condition
+        def loop_condition(i, sequence_example_protos, features_dict):
+            return tf.less(i, input_size)
+
+        # Define loop body
+        def loop_body(i, sequence_example_protos, features_dict):
+            features, labels = tfrecord_parse_fn(sequence_example_protos[i])
+            for feature, feature_val in features.items():
+                features_dict[feature] = features_dict[feature].write(
+                    i, tf.cast(feature_val, tf.float32)
+                )
+
+            i += 1
+
+            return i, sequence_example_protos, features_dict
+
+        # Parse all SequenceExample protos to get features
+        _, _, features_dict = tf.while_loop(
+            cond=loop_condition,
+            body=loop_body,
+            loop_vars=[i, sequence_example_protos, features_dict],
+        )
+
+        # Convert TensorArray to tensor
+        features_dict = {k: v.stack() for k, v in features_dict.items()}
+
+        # Run the model to get predictions
+        predictions = model(inputs=features_dict)
+
+        # Mask the padded records
+        for key, value in predictions.items():
+            predictions[key] = tf.where(
+                tf.equal(features_dict["mask"], 0), tf.constant(0.0), predictions[key]
+            )
+
+        return predictions
+
+    return _serve_tfrecord
+
+
+def define_serving_signatures(model, feature_config):
+    """Defines all serving signatures for the SavedModel"""
+    return {
+        # ServingSignatureKey.DEFAULT: define_default_signature(
+        #     model, feature_config),
+        ServingSignatureKey.TFRECORD: define_tfrecord_signature(model, feature_config)
+    }

--- a/python/ml4ir/model/serving.py
+++ b/python/ml4ir/model/serving.py
@@ -26,7 +26,7 @@ def define_default_signature(model, feature_config):
     return
 
 
-def define_tfrecord_signature(model, feature_config, pad_records):
+def define_tfrecord_signature(model, feature_config, pad_records, max_num_records):
     """
     Add signatures to the tf keras savedmodel
 
@@ -52,7 +52,7 @@ def define_tfrecord_signature(model, feature_config, pad_records):
     """
     tfrecord_parse_fn = make_parse_fn(
         feature_config=feature_config,
-        max_num_records=25,
+        max_num_records=max_num_records,
         required_only=True,
         pad_records=pad_records,
     )
@@ -110,10 +110,12 @@ def define_tfrecord_signature(model, feature_config, pad_records):
     return _serve_tfrecord
 
 
-def define_serving_signatures(model, feature_config, pad_records):
+def define_serving_signatures(model, feature_config, pad_records, max_num_records):
     """Defines all serving signatures for the SavedModel"""
     return {
         # ServingSignatureKey.DEFAULT: define_default_signature(
         #     model, feature_config),
-        ServingSignatureKey.TFRECORD: define_tfrecord_signature(model, feature_config, pad_records)
+        ServingSignatureKey.TFRECORD: define_tfrecord_signature(
+            model, feature_config, pad_records, max_num_records
+        )
     }

--- a/python/ml4ir/model/serving.py
+++ b/python/ml4ir/model/serving.py
@@ -26,7 +26,7 @@ def define_default_signature(model, feature_config):
     return
 
 
-def define_tfrecord_signature(model, feature_config):
+def define_tfrecord_signature(model, feature_config, pad_records):
     """
     Add signatures to the tf keras savedmodel
 
@@ -51,7 +51,10 @@ def define_tfrecord_signature(model, feature_config):
     Workaround: To infer on multiple queries, run predict() on each of the queries separately.
     """
     tfrecord_parse_fn = make_parse_fn(
-        feature_config=feature_config, max_num_records=25, required_only=True, pad_records=False
+        feature_config=feature_config,
+        max_num_records=25,
+        required_only=True,
+        pad_records=pad_records,
     )
     dtype_map = dict()
     for feature_info in feature_config.get_all_features(include_label=False):
@@ -107,10 +110,10 @@ def define_tfrecord_signature(model, feature_config):
     return _serve_tfrecord
 
 
-def define_serving_signatures(model, feature_config):
+def define_serving_signatures(model, feature_config, pad_records):
     """Defines all serving signatures for the SavedModel"""
     return {
         # ServingSignatureKey.DEFAULT: define_default_signature(
         #     model, feature_config),
-        ServingSignatureKey.TFRECORD: define_tfrecord_signature(model, feature_config)
+        ServingSignatureKey.TFRECORD: define_tfrecord_signature(model, feature_config, pad_records)
     }

--- a/python/ml4ir/tests/data/csv/feature_config.yaml
+++ b/python/ml4ir/tests/data/csv/feature_config.yaml
@@ -23,7 +23,7 @@ rank:
     shape: null
   serving_info:
     name: pos
-    required: false
+    required: true
     default_value: 0
   tfrecord_type: sequence
 label:

--- a/python/ml4ir/tests/data/csv/feature_config.yaml
+++ b/python/ml4ir/tests/data/csv/feature_config.yaml
@@ -10,6 +10,7 @@ query_key:
   serving_info:
     name: query_key
     required: false
+    default_value: 0
   tfrecord_type: context
 rank:
   name: pos
@@ -23,6 +24,7 @@ rank:
   serving_info:
     name: pos
     required: false
+    default_value: 0
   tfrecord_type: sequence
 label:
   name: label
@@ -36,6 +38,7 @@ label:
   serving_info:
     name: label
     required: false
+    default_value: 0
   tfrecord_type: sequence
 features:
   - name: feat_0
@@ -49,6 +52,7 @@ features:
     serving_info:
       name: feat_0
       required: true
+      default_value: 0.0
     tfrecord_type: sequence
   - name: feat_1
     node_name: feat_1
@@ -61,6 +65,7 @@ features:
     serving_info:
       name: feat_1
       required: true
+      default_value: 0.0
     tfrecord_type: sequence
   - name: feat_2
     node_name: feat_2
@@ -73,6 +78,7 @@ features:
     serving_info:
       name: feat_2
       required: true
+      default_value: 0.0
     tfrecord_type: sequence
   - name: query_str
     node_name: query_str
@@ -89,7 +95,8 @@ features:
       max_length: 20
     serving_info:
       name: query_str
-      required: false
+      required: true
+      default_value: ""
     tfrecord_type: context
   - name: group
     node_name: group
@@ -102,5 +109,6 @@ features:
       shape: null
     serving_info:
       name: group
-      required: true
+      required: false
+      default_value: 0
     tfrecord_type: context

--- a/python/ml4ir/tests/data/tfrecord/feature_config.yaml
+++ b/python/ml4ir/tests/data/tfrecord/feature_config.yaml
@@ -23,7 +23,7 @@ rank:
     shape: null
   serving_info:
     name: pos
-    required: false
+    required: true
     default_value: 0
   tfrecord_type: sequence
 label:

--- a/python/ml4ir/tests/data/tfrecord/feature_config.yaml
+++ b/python/ml4ir/tests/data/tfrecord/feature_config.yaml
@@ -10,6 +10,7 @@ query_key:
   serving_info:
     name: query_key
     required: false
+    default_value: 0
   tfrecord_type: context
 rank:
   name: pos
@@ -23,6 +24,7 @@ rank:
   serving_info:
     name: pos
     required: false
+    default_value: 0
   tfrecord_type: sequence
 label:
   name: label
@@ -36,6 +38,7 @@ label:
   serving_info:
     name: label
     required: false
+    default_value: 0
   tfrecord_type: sequence
 features:
   - name: feat_0
@@ -49,6 +52,7 @@ features:
     serving_info:
       name: feat_0
       required: true
+      default_value: 0.0
     tfrecord_type: sequence
   - name: feat_1
     node_name: feat_1
@@ -61,6 +65,7 @@ features:
     serving_info:
       name: feat_1
       required: true
+      default_value: 0.0
     tfrecord_type: sequence
   - name: feat_2
     node_name: feat_2
@@ -73,6 +78,7 @@ features:
     serving_info:
       name: feat_2
       required: true
+      default_value: 0.0
     tfrecord_type: sequence
   - name: query_str
     node_name: query_str
@@ -89,7 +95,8 @@ features:
       max_length: 20
     serving_info:
       name: query_str
-      required: false
+      required: true
+      default_value: ""
     tfrecord_type: context
   - name: group
     node_name: group
@@ -102,5 +109,6 @@ features:
       shape: null
     serving_info:
       name: group
-      required: true
+      required: false
+      default_value: 0
     tfrecord_type: context

--- a/python/ml4ir/tests/test_features.py
+++ b/python/ml4ir/tests/test_features.py
@@ -70,10 +70,12 @@ class RankingModelTest(RankingTestBase):
         """
         sequence_tensor = np.random.randint(256, size=(batch_size, 1, max_length))
 
-        sequence_embedding = get_sequence_encoding(
-            sequence_tensor, feature_info, self.args.max_num_records
-        )
+        sequence_encoding = get_sequence_encoding(sequence_tensor, feature_info)
 
-        assert sequence_embedding.shape[0] == batch_size
-        assert sequence_embedding.shape[1] == self.args.max_num_records
-        assert sequence_embedding.shape[2] == encoding_size
+        assert sequence_encoding.shape[0] == batch_size
+        assert (
+            sequence_encoding.shape[1] == 1
+            if feature_info["tfrecord_type"] == TFRecordTypeKey.CONTEXT
+            else self.args.max_num_records
+        )
+        assert sequence_encoding.shape[2] == encoding_size

--- a/python/ml4ir/tests/test_losses.py
+++ b/python/ml4ir/tests/test_losses.py
@@ -45,6 +45,7 @@ class RankingModelTest(RankingTestBase):
             learning_rate_decay_steps=self.args.learning_rate_decay_steps,
             gradient_clip_value=self.args.gradient_clip_value,
             compute_intermediate_stats=self.args.compute_intermediate_stats,
+            compile_keras_model=self.args.compile_keras_model,
             logger=self.logger,
         )
 

--- a/python/ml4ir/tests/test_metrics.py
+++ b/python/ml4ir/tests/test_metrics.py
@@ -52,6 +52,7 @@ class RankingModelTest(RankingTestBase):
             learning_rate_decay_steps=self.args.learning_rate_decay_steps,
             gradient_clip_value=self.args.gradient_clip_value,
             compute_intermediate_stats=self.args.compute_intermediate_stats,
+            compile_keras_model=self.args.compile_keras_model,
             logger=self.logger,
         )
 

--- a/python/ml4ir/tests/test_ranking_model.py
+++ b/python/ml4ir/tests/test_ranking_model.py
@@ -49,6 +49,7 @@ class RankingModelTest(RankingTestBase):
             learning_rate_decay_steps=self.args.learning_rate_decay_steps,
             gradient_clip_value=self.args.gradient_clip_value,
             compute_intermediate_stats=self.args.compute_intermediate_stats,
+            compile_keras_model=self.args.compile_keras_model,
             logger=self.logger,
         )
 

--- a/python/ml4ir/tests/test_serving.py
+++ b/python/ml4ir/tests/test_serving.py
@@ -178,7 +178,10 @@ class RankingModelTest(RankingTestBase):
                     ).SerializeToString()
                 ]
             )
-            tfrecord_signature(sequence_example_protos=proto)
+            try:
+                tfrecord_signature(sequence_example_protos=proto)
+            except Exception:
+                assert False
 
     def test_serving_required_fields_only(self):
         """Test serving signature with protos with only required fields"""
@@ -217,4 +220,8 @@ class RankingModelTest(RankingTestBase):
         proto = tf.constant(
             [feature_config.create_dummy_sequence_example(required_only=True).SerializeToString()]
         )
-        tfrecord_signature(sequence_example_protos=proto)
+
+        try:
+            tfrecord_signature(sequence_example_protos=proto)
+        except Exception:
+            assert False

--- a/python/ml4ir/tests/test_serving.py
+++ b/python/ml4ir/tests/test_serving.py
@@ -61,6 +61,7 @@ class RankingModelTest(RankingTestBase):
             learning_rate_decay_steps=self.args.learning_rate_decay_steps,
             compute_intermediate_stats=self.args.compute_intermediate_stats,
             gradient_clip_value=self.args.gradient_clip_value,
+            compile_keras_model=self.args.compile_keras_model,
             logger=self.logger,
         )
 

--- a/python/ml4ir/tests/test_serving.py
+++ b/python/ml4ir/tests/test_serving.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 
 
 class RankingModelTest(RankingTestBase):
-    def _test_model_serving(self):
+    def test_model_serving(self):
         """
         Train a simple model and test serving flow by loading the SavedModel
         """

--- a/python/ml4ir/tests/test_serving.py
+++ b/python/ml4ir/tests/test_serving.py
@@ -94,6 +94,9 @@ class RankingModelTest(RankingTestBase):
         default_signature_predictions = default_signature(**parsed_sequence_examples)[
             "ranking_scores"
         ]
+        import pdb
+
+        pdb.set_trace()
         tfrecord_signature_predictions = tfrecord_signature(
             sequence_example_protos=sequence_example_protos
         )["ranking_scores"]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -76,7 +76,16 @@ six==1.14.0
 sklearn==0.0
 swifter==0.296
 tblib==1.5.0
-tensorflow==2.1
+tensorboard==2.0.1
+tensorflow==2.0.1
+tensorflow-estimator==2.0.1
+tensorflow-hub==0.7.0
+tensorflow-metadata==0.15.1
+tensorflow-probability==0.8.0
+tensorflow-ranking==0.2.0
+tensorflow-serving-api==2.0.0
+tensorflow-text==2.0.1
+tensorflow-transform==0.15.0
 traitlets==4.3.3
 urllib3==1.25.7
 wcwidth==0.1.8

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -76,16 +76,7 @@ six==1.14.0
 sklearn==0.0
 swifter==0.296
 tblib==1.5.0
-tensorboard==2.0.1
-tensorflow==2.0.1
-tensorflow-estimator==2.0.1
-tensorflow-hub==0.7.0
-tensorflow-metadata==0.15.1
-tensorflow-probability==0.8.0
-tensorflow-ranking==0.2.0
-tensorflow-serving-api==2.0.0
-tensorflow-text==2.0.1
-tensorflow-transform==0.15.0
+tensorflow==2.1
 traitlets==4.3.3
 urllib3==1.25.7
 wcwidth==0.1.8


### PR DESCRIPTION
Things covered in the PR:
- create dummy values for fields that are not required
- not pad records for inference
- regenerate the models with updated serving signature(without retraining)