### PR TITLE
Moving the default_value under serving_info in yaml

### DIFF
--- a/jvm/ml4ir-inference/pom.xml
+++ b/jvm/ml4ir-inference/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>ml4ir</groupId>
     <artifactId>ml4ir-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>ml4ir-inference</artifactId>
   <packaging>jar</packaging>
 
   <properties>
-    <jackson.version>2.7.5</jackson.version>
+    <jackson.version>2.10.0</jackson.version>
   </properties>
 
   <build>

--- a/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/ModelExecutorConfig.scala
+++ b/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/ModelExecutorConfig.scala
@@ -1,6 +1,4 @@
 package ml4ir.inference.tensorflow
 
 case class ModelExecutorConfig(queryNodeName: String,
-                               scoresNodeName: String,
-                               numDocsPerQuery: Int,
-                               queryLenMax: Int)
+                               scoresNodeName: String)

--- a/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/SavedModelBundleExecutor.scala
+++ b/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/SavedModelBundleExecutor.scala
@@ -24,7 +24,7 @@ class SavedModelBundleExecutor(dirPath: String, config: ModelExecutorConfig) ext
   val session = savedModelBundle.session()
 
   override def apply(proto: SequenceExample): Array[Float] = {
-    val ModelExecutorConfig(inputNode, outputNode, _, _) = config
+    val ModelExecutorConfig(inputNode, outputNode) = config
     val inputTensor: Tensor[String] = Tensors.create(Array(proto.toByteArray))
     try {
       val resultTensor: Tensor[_] = session

--- a/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/data/FeaturesConfigHelper.scala
+++ b/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/data/FeaturesConfigHelper.scala
@@ -12,7 +12,7 @@ object FeaturesConfigHelper {
           .groupBy(_.dType)
           .mapValues(
             _.map {
-              case FeatureConfig(nodeName, _, ServingConfig(servingName), defaultValue, _) =>
+              case FeatureConfig(nodeName, _, ServingConfig(servingName, defaultValue), _) =>
                 servingName -> NodeWithDefault(nodeName, defaultValue)
             }.toMap
           )

--- a/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/data/ModelFeaturesConfig.scala
+++ b/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/data/ModelFeaturesConfig.scala
@@ -29,10 +29,10 @@ case class ModelFeaturesConfig(@JsonProperty("rank") initialRank: FeatureConfig,
 case class FeatureConfig(@JsonProperty("node_name") nodeName: String,
                          @JsonProperty("dtype") dTypeString: String,
                          @JsonProperty("serving_info") servingConfig: ServingConfig,
-                         @JsonProperty("default_value") defaultValue: String,
                          @JsonProperty("tfrecord_type") tfRecordType: String) {
   def dType: DataType = DataType.valueOf(dTypeString.toUpperCase)
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-case class ServingConfig(@JsonProperty("name") servingName: String)
+case class ServingConfig(@JsonProperty("name") servingName: String,
+                         @JsonProperty("default_value") defaultValue: String)

--- a/jvm/ml4ir-inference/src/test/resources/model_features.yaml
+++ b/jvm/ml4ir-inference/src/test/resources/model_features.yaml
@@ -11,8 +11,8 @@ query_key:
   serving_info:
     name: query_key
     required: false
+    default_value: ""
   tfrecord_type: context
-  default_value: ""
 rank:
   name: rank
   node_name: rank
@@ -25,8 +25,8 @@ rank:
   serving_info:
     name: rank
     required: false
+    default_value: 0
   tfrecord_type: sequence
-  default_value: 0
 label:
   name: label
   node_name: label
@@ -39,8 +39,8 @@ label:
   serving_info:
     name: label
     required: false
+    default_value: 0
   tfrecord_type: sequence
-  default_value: 0
 features:
   - name: query
     node_name: query_text
@@ -55,8 +55,8 @@ features:
     serving_info:
       name: q
       required: true
+      default_value: ""
     tfrecord_type: context
-    default_value: ""
   - name: user
     node_name: user_id
     trainable: false
@@ -69,8 +69,8 @@ features:
     serving_info:
       name: userId
       required: false
+      default_value: "__UNKNOWN_USER__"
     tfrecord_type: context
-    default_value: "__UNKNOWN_USER__"
   - name: context_float_1
     node_name: context_float_1
     trainable: true
@@ -83,8 +83,8 @@ features:
     serving_info:
       name: context_float_1
       required: false
+      default_value: 0
     tfrecord_type: context
-    default_value: 0
   - name: context_float_2
     node_name: context_float_2
     trainable: true
@@ -97,8 +97,8 @@ features:
     serving_info:
       name: context_float_2
       required: false
+      default_value: 1.5
     tfrecord_type: context
-    default_value: 1.5
 # NOTE: no context longs, so we verify the parser doesn't blow up when not all types are specified
 #  - name: context_long_1
 #    node_name: context_long_1
@@ -126,8 +126,8 @@ features:
 #    serving_info:
 #      name: context_long_2
 #      required: false
+#      default_value: 2147483649
 #    tfrecord_type: context
-#    default_value: 2147483649
   - name: title
     node_name: doc_title
     trainable: false
@@ -140,8 +140,8 @@ features:
     serving_info:
       name: docTitle
       required: false
+      default_value: ""
     tfrecord_type: sequence
-    default_value: ""
   - name: sequence_string_2
     node_name: sequence_string_2
     trainable: false
@@ -154,8 +154,8 @@ features:
     serving_info:
       name: sequence_string_2
       required: false
+      default_value: "sequence_string_2"
     tfrecord_type: sequence
-    default_value: "sequence_string_2"
   - name: popularity
     node_name: doc_popularity
     trainable: true
@@ -168,8 +168,8 @@ features:
     serving_info:
       name: docPopularity
       required: false
+      default_value: 0
     tfrecord_type: sequence
-    default_value: 0
   - name: age
     node_name: doc_age_in_hours
     trainable: true
@@ -182,8 +182,8 @@ features:
     serving_info:
       name: docAgeHours
       required: false
+      default_value: 2400.0
     tfrecord_type: sequence
-    default_value: 2400.0
   - name: views
     node_name: doc_views
     trainable: true
@@ -196,8 +196,8 @@ features:
     serving_info:
       name: numDocumentViews
       required: false
+      default_value: 0
     tfrecord_type: sequence
-    default_value: 0
   - name: sequence_long_2
     node_name: sequence_long_2
     trainable: true
@@ -210,5 +210,5 @@ features:
     serving_info:
       name: sequence_long_2
       required: false
+      default_value: 2147483649
     tfrecord_type: sequence
-    default_value: 2147483649

--- a/jvm/ml4ir-inference/src/test/scala/ml4ir/inference/tensorflow/ModelFeaturesConfigParserTest.scala
+++ b/jvm/ml4ir-inference/src/test/scala/ml4ir/inference/tensorflow/ModelFeaturesConfigParserTest.scala
@@ -12,7 +12,7 @@ class ModelFeaturesConfigParserTest {
       ModelFeaturesConfig.load(getClass.getClassLoader.getResource("model_features.yaml").getPath)
     assertEquals("incorrect feature count from config", 10, mf.features.size)
     mf.features
-      .map { case FeatureConfig(train, _, ServingConfig(inference), _, _) => inference -> train }
+      .map { case FeatureConfig(train, _, ServingConfig(inference, _), _) => inference -> train }
       .foreach(println)
   }
 }

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ml4ir</groupId>
   <artifactId>ml4ir-parent</artifactId>
-  <version>0.0.1</version>
+  <version>0.0.2-SNAPSHOT</version>
   <name>ml4ir-parent</name>
   <packaging>pom</packaging>
 
@@ -13,7 +13,7 @@
     <scala.version>2.11.8</scala.version>
     <scala.artifact.suffix>2.11</scala.artifact.suffix>
     <tensorflow.version>1.15.0</tensorflow.version>
-    <jackson.version>2.7.5</jackson.version>
+    <jackson.version>2.10.0</jackson.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
- Moving the default_value under serving_info section in yaml
- Updating the parsing code for the new yaml format
- Removing extra args from ModelExecutorConfig
- Updating the jackson lib version
- Updating the ml4ir version to 0.0.2-SNAPSHOT