### PR TITLE
git2gus: update default release to 230

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,4 +1,4 @@
 {
   "productTag": "a1aB00000000dkkIAA",
-  "defaultBuild": "228"
+  "defaultBuild": "230"
 }


### PR DESCRIPTION
self explanatory git2gus config update