### PR TITLE
Prototyping factory for optimizers

### DIFF
--- a/python/ml4ir/applications/classification/pipeline.py
+++ b/python/ml4ir/applications/classification/pipeline.py
@@ -69,7 +69,7 @@ class ClassificationPipeline(RelevancePipeline):
             learning_rate=self.args.learning_rate,
             learning_rate_decay=self.args.learning_rate_decay,
             learning_rate_decay_steps=self.args.learning_rate_decay_steps,
-            gradient_clip_value=self.args.gradient_clip_value,
+            clipvalue=self.args.gradient_clip_value,
         )
 
         # Combine the above to define a RelevanceModel

--- a/python/ml4ir/applications/ranking/pipeline.py
+++ b/python/ml4ir/applications/ranking/pipeline.py
@@ -70,7 +70,7 @@ class RankingPipeline(RelevancePipeline):
             learning_rate=self.args.learning_rate,
             learning_rate_decay=self.args.learning_rate_decay,
             learning_rate_decay_steps=self.args.learning_rate_decay_steps,
-            gradient_clip_value=self.args.gradient_clip_value,
+            clipvalue=self.args.gradient_clip_value,
         )
 
         # Combine the above to define a RelevanceModel

--- a/python/ml4ir/applications/ranking/tests/test_base.py
+++ b/python/ml4ir/applications/ranking/tests/test_base.py
@@ -126,7 +126,7 @@ class RankingTestBase(unittest.TestCase):
             learning_rate=self.args.learning_rate,
             learning_rate_decay=self.args.learning_rate_decay,
             learning_rate_decay_steps=self.args.learning_rate_decay_steps,
-            gradient_clip_value=self.args.gradient_clip_value,
+            clipvalue=self.args.gradient_clip_value,
         )
 
         # Combine the above to define a RelevanceModel

--- a/python/ml4ir/base/config/keys.py
+++ b/python/ml4ir/base/config/keys.py
@@ -22,16 +22,6 @@ class ArchitectureKey(Key):
     RNN = "rnn"
 
 
-class OptimizerKey(Key):
-    """Model optimizer keys"""
-
-    ADAM = "adam"
-    ADAGRAD = "adagrad"
-    NADAM = "nadam"
-    SGD = "sgd"
-    RMS_PROP = "rms_prop"
-
-
 class DataFormatKey(Key):
     """Data Format keys"""
 

--- a/python/ml4ir/base/config/parse_args.py
+++ b/python/ml4ir/base/config/parse_args.py
@@ -59,7 +59,7 @@ class RelevanceArgParser(ArgumentParser):
         self.add_argument(
             "--optimizer_key",
             type=str,
-            default="adam",
+            default="Adam",
             help="Optimizer to use. Has to be one of the optimizers in OptimizerKey under "
             "ml4ir/config/keys.py",
         )

--- a/python/ml4ir/base/model/optimizer.py
+++ b/python/ml4ir/base/model/optimizer.py
@@ -1,13 +1,10 @@
 import tensorflow.keras.optimizers as tf_optimizers
 from tensorflow.keras.optimizers.schedules import ExponentialDecay
 
-from ml4ir.base.config.keys import OptimizerKey
-
 
 def get_optimizer(
-    optimizer_key: str = "SGD",
-    with_exp_decay: bool = False,
-    initial_learning_rate: float = 0.01,
+    optimizer_key: str = "Adam",
+    learning_rate: float = 0.01,
     learning_rate_decay: float = 1.0,
     learning_rate_decay_steps: int = 1000000,
     **kwargs
@@ -25,10 +22,12 @@ def get_optimizer(
     Arguments:
         optimizer_key: string optimizer name to be used as defined
          under tensorflow.keras.optimizers
-        with_exp_decay: Set to True, to add Exponential Decay schedule
-        learning_rate_decay,learning_rate_decay, learning_rate_decay_steps:
+        learning_rate: learing rate to be used in the optimizer. If the user passes valid arguments
+        for learning rate decay, then this is the initial learning rate
+        learning_rate_decay, learning_rate_decay_steps:
         Params controlling the decay schedule,
          cf. https://www.tensorflow.org/api_docs/python/tf/keras/optimizers/schedules/ExponentialDecay
+        If learning_rate_decay < 1.0 we use it as an explicit signal to add decay.
 
     You may pass any other valid arguments to the function to control aspects of the optimizer,
     according to the official tensforflow documentation.
@@ -48,7 +47,7 @@ def get_optimizer(
     """
     # Define an exponential learning rate decay schedule
     learning_rate_schedule = ExponentialDecay(
-        initial_learning_rate,
+        learning_rate,
         decay_steps=learning_rate_decay_steps,
         decay_rate=learning_rate_decay,
         staircase=True,
@@ -60,6 +59,6 @@ def get_optimizer(
         raise AttributeError("ml4ir uses 'tensorflow.keras.optimizers' as a factory of optimizers. "
                              "You provided {}, which does not exist in that module.".format(optimizer_key))
 
-    if with_exp_decay:
-        return optimizer(learning_rate = learning_rate_schedule, **kwargs)
-    return optimizer(**kwargs)
+    if learning_rate_decay < 1.0:  # The user explicitly passed this, so we want decay
+        return optimizer(learning_rate=learning_rate_schedule, **kwargs)
+    return optimizer(learning_rate=learning_rate, **kwargs)

--- a/python/ml4ir/base/model/optimizer.py
+++ b/python/ml4ir/base/model/optimizer.py
@@ -5,58 +5,61 @@ from ml4ir.base.config.keys import OptimizerKey
 
 
 def get_optimizer(
-    optimizer_key: str,
-    learning_rate: float,
+    optimizer_key: str = "SGD",
+    with_exp_decay: bool = False,
+    initial_learning_rate: float = 0.01,
     learning_rate_decay: float = 1.0,
     learning_rate_decay_steps: int = 1000000,
-    gradient_clip_value: float = 1000000,
+    **kwargs
 ) -> tf_optimizers.Optimizer:
     """
     This function defines the optimizer used by ml4ir.
-    Users have the option to define an ExponentialDecay learning rate schedule
+    By default, if no arguments are passed the function returns
+    vanilla SGD. Given a valid optimizer key, the function will return
+    the passed optimizer, with its default params. You may pass any other
+    valid arguments to the function to control aspects of the optimizer,
+    according to the official Tensorflow documentation. See References below.
+
+    Users may use an ExponentialDecay learning rate schedule.
 
     Arguments:
-        optimizer_key: string optimizer name to be used as defined under ml4ir.base.config.keys.OptimizerKey
-        learning_rate: floating point learning rate for the optimizer
-        learning_rate_decay: floating point rate at which the learning rate will be decayed every learning_rate_decay_steps
-        learning_rate_decay_steps: int representing number of iterations after which learning rate will be decreased exponentially
-        gradient_clip_value: float value representing the clipvalue for gradient updates. Not setting this to a reasonable value based on the model will lead to gradient explosion and NaN losses.
+        optimizer_key: string optimizer name to be used as defined
+         under tensorflow.keras.optimizers
+        with_exp_decay: Set to True, to add Exponential Decay schedule
+        learning_rate_decay,learning_rate_decay, learning_rate_decay_steps:
+        Params controlling the decay schedule,
+         cf. https://www.tensorflow.org/api_docs/python/tf/keras/optimizers/schedules/ExponentialDecay
+
+    You may pass any other valid arguments to the function to control aspects of the optimizer,
+    according to the official tensforflow documentation.
 
     References:
         https://www.tensorflow.org/api_docs/python/tf/keras/optimizers/Optimizer
         https://www.tensorflow.org/api_docs/python/tf/keras/optimizers/schedules/ExponentialDecay
 
+
+    Examples:
+        get_optimizer() -> SGD optimizer
+        get_optimizer('Adam', learning_rate=0.002) -> Adam, with lr=0.002
     FIXME:
         Define all arguments overriding tensorflow defaults in a separate file
         for visibility with ml4ir users
+
     """
     # Define an exponential learning rate decay schedule
     learning_rate_schedule = ExponentialDecay(
-        learning_rate,
+        initial_learning_rate,
         decay_steps=learning_rate_decay_steps,
         decay_rate=learning_rate_decay,
         staircase=True,
     )
 
-    if optimizer_key == OptimizerKey.ADAM:
-        return tf_optimizers.Adam(
-            learning_rate=learning_rate_schedule, clipvalue=gradient_clip_value
-        )
-    elif optimizer_key == OptimizerKey.NADAM:
-        return tf_optimizers.Nadam(
-            learning_rate=learning_rate_schedule, clipvalue=gradient_clip_value
-        )
-    elif optimizer_key == OptimizerKey.ADAGRAD:
-        return tf_optimizers.Adagrad(
-            learning_rate=learning_rate_schedule, clipvalue=gradient_clip_value
-        )
-    elif optimizer_key == OptimizerKey.SGD:
-        return tf_optimizers.SGD(
-            learning_rate=learning_rate_schedule, clipvalue=gradient_clip_value
-        )
-    elif optimizer_key == OptimizerKey.RMS_PROP:
-        return tf_optimizers.RMSprop(
-            learning_rate=learning_rate_schedule, clipvalue=gradient_clip_value
-        )
-    else:
-        raise ValueError("illegal Optimizer key: " + optimizer_key)
+    try:
+        optimizer = getattr(tf_optimizers, optimizer_key)  # returns the class
+    except AttributeError:
+        raise AttributeError("ml4ir uses 'tensorflow.keras.optimizers' as a factory of optimizers. "
+                             "You provided {}, which does not exist in that module.".format(optimizer_key))
+
+    if with_exp_decay:
+        return optimizer(learning_rate = learning_rate_schedule, **kwargs)
+    return optimizer(**kwargs)

--- a/python/ml4ir/base/pipeline.py
+++ b/python/ml4ir/base/pipeline.py
@@ -149,13 +149,6 @@ class RelevancePipeline(object):
                 )
             )
 
-        if self.optimizer_key not in OptimizerKey.get_all_keys():
-            raise Exception(
-                "Optimizer specified [{}] is not one of : {}".format(
-                    self.optimizer_key, OptimizerKey.get_all_keys()
-                )
-            )
-
         if self.data_format not in DataFormatKey.get_all_keys():
             raise Exception(
                 "Data format[{}] is not one of : {}".format(

--- a/python/ml4ir/base/pipeline.py
+++ b/python/ml4ir/base/pipeline.py
@@ -19,7 +19,6 @@ from ml4ir.base.io.local_io import LocalIO
 from ml4ir.base.io.spark_io import SparkIO
 from ml4ir.base.data.relevance_dataset import RelevanceDataset
 from ml4ir.base.model.relevance_model import RelevanceModel
-from ml4ir.base.config.keys import OptimizerKey
 from ml4ir.base.config.keys import DataFormatKey
 from ml4ir.base.config.keys import ExecutionModeKey
 from ml4ir.base.config.keys import TFRecordTypeKey


### PR DESCRIPTION
A common pattern is to use `ml4ir.base.config.keys` to use some keywords to control functionality. This is error prone, difficult to maintain and can cause limitations. 

This PR starts this discussion proposing an alternative way to do it. Happy to hear back your thought. 

It is not finished work, it just points the direction. But if we were to agree on something like this it means we automatically support everything tf does. And we can make the `ml4ir.base.config.keys` smaller. There are also other places that will benefit (discussed offline with Ashish). 