### PR TITLE
adding support to configure LSTM kernel initializer

### DIFF
--- a/python/ml4ir/base/features/feature_fns/categorical.py
+++ b/python/ml4ir/base/features/feature_fns/categorical.py
@@ -167,10 +167,10 @@ def categorical_embedding_to_encoding_bilstm(feature_tensor, feature_info, file_
     )(categorical_indices)
 
     categorical_embeddings = tf.squeeze(categorical_embeddings, axis=1)
-    if args['lstm_keras_initializer']:
+    if args['lstm_kernel_initializer']:
         encoding = get_bilstm_encoding(embedding=categorical_embeddings,
                                        lstm_units=int(args["encoding_size"] / 2),
-                                       kernel_initializer=args['lstm_keras_initializer'])
+                                       kernel_initializer=args['lstm_kernel_initializer'])
     else:
         encoding = get_bilstm_encoding(embedding=categorical_embeddings,
                                        lstm_units=int(args["encoding_size"] / 2))

--- a/python/ml4ir/base/features/feature_fns/categorical.py
+++ b/python/ml4ir/base/features/feature_fns/categorical.py
@@ -167,13 +167,10 @@ def categorical_embedding_to_encoding_bilstm(feature_tensor, feature_info, file_
     )(categorical_indices)
 
     categorical_embeddings = tf.squeeze(categorical_embeddings, axis=1)
-    if args['lstm_kernel_initializer']:
-        encoding = get_bilstm_encoding(embedding=categorical_embeddings,
-                                       lstm_units=int(args["encoding_size"] / 2),
-                                       kernel_initializer=args['lstm_kernel_initializer'])
-    else:
-        encoding = get_bilstm_encoding(embedding=categorical_embeddings,
-                                       lstm_units=int(args["encoding_size"] / 2))
+    kernel_initializer = args.get('lstm_kernel_initializer', 'glorot_uniform')
+    encoding = get_bilstm_encoding(embedding=categorical_embeddings,
+                                   lstm_units=int(args["encoding_size"] / 2),
+                                   kernel_initializer=kernel_initializer)
     return encoding
 
 

--- a/python/ml4ir/base/features/feature_fns/categorical.py
+++ b/python/ml4ir/base/features/feature_fns/categorical.py
@@ -167,7 +167,13 @@ def categorical_embedding_to_encoding_bilstm(feature_tensor, feature_info, file_
     )(categorical_indices)
 
     categorical_embeddings = tf.squeeze(categorical_embeddings, axis=1)
-    encoding = get_bilstm_encoding(categorical_embeddings, int(args["encoding_size"] / 2))
+    if args['lstm_keras_initializer']:
+        encoding = get_bilstm_encoding(embedding=categorical_embeddings,
+                                       lstm_units=int(args["encoding_size"] / 2),
+                                       kernel_initializer=args['lstm_keras_initializer'])
+    else:
+        encoding = get_bilstm_encoding(embedding=categorical_embeddings,
+                                       lstm_units=int(args["encoding_size"] / 2))
     return encoding
 
 

--- a/python/ml4ir/base/features/feature_fns/sequence.py
+++ b/python/ml4ir/base/features/feature_fns/sequence.py
@@ -50,10 +50,10 @@ def bytes_sequence_to_encoding_bilstm(feature_tensor, feature_info, file_io: Fil
     else:
         char_embedding = tf.one_hot(feature_tensor, depth=256)
 
-    if args['lstm_keras_initializer']:
+    if args['lstm_kernel_initializer']:
         encoding = get_bilstm_encoding(embedding=char_embedding,
                                        lstm_units=int(args["encoding_size"] / 2),
-                                       kernel_initializer=args['lstm_keras_initializer'])
+                                       kernel_initializer=args['lstm_kernel_initializer'])
     else:
         encoding = get_bilstm_encoding(embedding=char_embedding,
                                        lstm_units=int(args["encoding_size"] / 2))

--- a/python/ml4ir/base/features/feature_fns/sequence.py
+++ b/python/ml4ir/base/features/feature_fns/sequence.py
@@ -50,14 +50,10 @@ def bytes_sequence_to_encoding_bilstm(feature_tensor, feature_info, file_io: Fil
     else:
         char_embedding = tf.one_hot(feature_tensor, depth=256)
 
-    if args['lstm_kernel_initializer']:
-        encoding = get_bilstm_encoding(embedding=char_embedding,
-                                       lstm_units=int(args["encoding_size"] / 2),
-                                       kernel_initializer=args['lstm_kernel_initializer'])
-    else:
-        encoding = get_bilstm_encoding(embedding=char_embedding,
-                                       lstm_units=int(args["encoding_size"] / 2))
-
+    kernel_initializer = args.get('lstm_kernel_initializer', 'glorot_uniform')
+    encoding = get_bilstm_encoding(embedding=char_embedding,
+                                   lstm_units=int(args["encoding_size"] / 2),
+                                   kernel_initializer=kernel_initializer)
     return encoding
 
 

--- a/python/ml4ir/base/features/feature_fns/sequence.py
+++ b/python/ml4ir/base/features/feature_fns/sequence.py
@@ -50,17 +50,27 @@ def bytes_sequence_to_encoding_bilstm(feature_tensor, feature_info, file_io: Fil
     else:
         char_embedding = tf.one_hot(feature_tensor, depth=256)
 
-    encoding = get_bilstm_encoding(char_embedding, int(args["encoding_size"] / 2))
+    if args['lstm_keras_initializer']:
+        encoding = get_bilstm_encoding(embedding=char_embedding,
+                                       lstm_units=int(args["encoding_size"] / 2),
+                                       kernel_initializer=args['lstm_keras_initializer'])
+    else:
+        encoding = get_bilstm_encoding(embedding=char_embedding,
+                                       lstm_units=int(args["encoding_size"] / 2))
 
     return encoding
 
 
-def get_bilstm_encoding(embedding, units):
+def get_bilstm_encoding(embedding, lstm_units, kernel_initializer='glorot_uniform'):
     """
     Builds a bilstm on to on the embedding passed as input.
+    :param embedding: sequence of input embeddings to be passed through the BiLSTM
+    :param lstm_units number of units in each of the LSTMs of the BiLSTM
+    :param kernel_initializer, str any shortcut of the supported tf.keras.initializers
+      e.g., 'ones', 'glorot_uniform', 'lecun_normal' ...
     """
     encoding = layers.Bidirectional(
-        layers.LSTM(units=units, return_sequences=False), merge_mode="concat",
-    )(embedding)
+        layers.LSTM(units=lstm_units, return_sequences=False,
+                    kernel_initializer=kernel_initializer),merge_mode="concat")(embedding)
     encoding = tf.expand_dims(encoding, axis=1)
     return encoding


### PR DESCRIPTION
Currently, when encoding sequences using BiLSTM, the code uses by default the 'glorot_uniform' kernel initialization of LSTMs. 
This PR adds functionality so that a user can configure the type of initialization to any of https://www.tensorflow.org/api_docs/python/tf/keras/initializers

@rev mbrette
@rev lastmansleeping
@rev Ullimague