### PR TITLE
evaluation of classification models is slow

### DIFF
--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 import pandas as pd
 from tensorflow import data
 from ml4ir.base.model.relevance_model import RelevanceModelConstants
@@ -58,21 +59,16 @@ class ClassificationModel(RelevanceModel):
         if not self.is_compiled:
             return NotImplementedError
         group_metrics_keys = self.feature_config.get_group_metrics_keys()
-
         metrics_dict = self.model.evaluate(test_dataset)
         metrics_dict = dict(zip(self.model.metrics_names, metrics_dict))
         predictions = self.predict(test_dataset,
                                    inference_signature=inference_signature,
                                    additional_features=additional_features,
-                                   logs_dir=None,  # Return pd.DataFrame of predictions
+                                   logs_dir=None,
                                    logging_frequency=logging_frequency)
-        # Need to convert predictions from tuples of tf.Tensor to lists of int/float
-        # so that we are compatible with tf.keras.metrics
+
         label_name = self.feature_config.get_label()['name']
         output_name = self.output_name
-        predictions[label_name] = predictions[label_name].apply(lambda l: [item.numpy() for item in l])
-        predictions[output_name] = predictions[output_name].apply(lambda l: [item.numpy() for item in l])
-
         global_metrics = []  # group_name, metric, value
         grouped_metrics = []
         for metric in self.model.metrics:
@@ -106,3 +102,57 @@ class ClassificationModel(RelevanceModel):
             )
             self.logger.info(f"Evaluation Results written at: {logs_dir}")
         return global_metrics, grouped_metrics, metrics_dict
+
+    def predict(
+        self,
+        test_dataset: data.TFRecordDataset,
+        inference_signature: str = "serving_default",
+        additional_features: dict = {},
+        logs_dir: Optional[str] = None,
+        logging_frequency: int = 25,
+    ):
+        """
+        Predict the scores on the test dataset using the trained model
+
+        Parameters
+        ----------
+        test_dataset : `Dataset` object
+            `Dataset` object for which predictions are to be made
+        inference_signature : str, optional
+            If using a SavedModel for prediction, specify the inference signature to be used for computing scores
+        additional_features : dict, optional
+            Dictionary containing new feature name and function definition to
+            compute them. Use this to compute additional features from the scores.
+            For example, converting ranking scores for each document into ranks for
+            the query
+        logs_dir : str, optional
+            Path to directory to save logs
+        logging_frequency : int
+            Value representing how often(in batches) to log status
+
+        Returns
+        -------
+        `pd.DataFrame`
+            pandas DataFrame containing the predictions on the test dataset
+            made with the `RelevanceModel`
+        """
+        if logs_dir:
+            outfile = os.path.join(logs_dir, RelevanceModelConstants.MODEL_PREDICTIONS_CSV_FILE)
+            # Delete file if it exists
+            self.file_io.rm_file(outfile)
+
+        predictions_df_list = list()
+        for (x, y) in test_dataset.take(-1):  # returns (x, y) tuples
+            batch_predictions = pd.DataFrame({key: np.squeeze(x[key].numpy()).tolist() for key in x.keys()})
+            batch_predictions[self.feature_config.get_label()["name"]] = np.squeeze(y.numpy()).tolist()
+            predictions_df_list.append(batch_predictions)
+        predictions_df = pd.concat(predictions_df_list)
+        predictions_df[self.output_name] = np.squeeze(self.model.predict(test_dataset)).tolist()
+        features_to_log = [f.get("node_name", f["name"]) for f in self.feature_config.get_features_to_log()] + [self.output_name]
+        predictions_df = predictions_df[features_to_log]
+        if logs_dir:
+            predictions_df.to_csv(outfile, mode="w", header=True, index=False)
+            self.logger.info("Model predictions written to -> {}".format(outfile))
+
+        return predictions_df
+


### PR DESCRIPTION
when evaluating a classification model, there is a log message "2020-11-03 00:45:25.599392: W tensorflow/core/grappler/optimizers/implementation_selector.cc:310] Skipping optimization due to error while loading function libraries: Invalid argument: Functions '__inference_standard_lstm_326453' and '__inference_standard_lstm_326453_specialized_for_model_1_bidirectional_backward_lstm_StatefulPartitionedCall_at___inference__predict_score_328540' both implement 'lstm_2e98d781-3305-4503-8a74-a0e21edaacd6' but their signatures do not match." 
This seems to [be a known issue](https://github.com/tensorflow/tensorflow/issues/30263).  

This makes inference very slow.. Local tests found we are at least 15x slower than calling model's predict. This PR re-writes the classification `predict` function making it 15x faster.