### PR TITLE
Allows to run integration tests with local Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ We use CircleCI for running tests. Both jvm and python tests will run on each co
 
 Unit test can be run from the Python/Java IDEs directly or with dedictated `mvn` or `python` command
 
-For integration test, you need to run the `mvn verify -Pintegration_tests` in the jvm directory *after* enabling your Python environement as described in the python README.md
+For integration test, you need to run, in the `jvm` directory:
+* `mvn verify -Pintegration_tests` *after* enabling your Python environement as described in the python README.md
+* or, if you prefer running the Python training in Docker, `mvn verify -Pintegration_tests -DuseDocker`
 
 ## Documentation
 

--- a/jvm/ml4ir-inference/pom.xml
+++ b/jvm/ml4ir-inference/pom.xml
@@ -40,6 +40,7 @@
                   <executable>${basedir}/scripts/generate_model.sh</executable>
                   <arguments>
                     <argument>${runName}</argument>
+                    <argument>${useDocker}</argument>
                   </arguments>
                 </configuration>
               </execution>

--- a/jvm/ml4ir-inference/scripts/generate_model.sh
+++ b/jvm/ml4ir-inference/scripts/generate_model.sh
@@ -8,7 +8,15 @@ cd ${DIR}/../../../python
 
 CLASSIFICATION_MODEL=ml4ir/applications/classification
 
-PYTHONPATH=. python ${CLASSIFICATION_MODEL}/pipeline.py \
+if [ -z "$2" ]
+  then
+    export PYTHONPATH=.
+    EXECUTOR="python"
+else
+  EXECUTOR="docker-compose run ml4ir python"
+fi
+
+$EXECUTOR ${CLASSIFICATION_MODEL}/pipeline.py \
     --data_dir ${CLASSIFICATION_MODEL}/tests/data/csv/  \
     --feature_config ${CLASSIFICATION_MODEL}/tests/data/configs/feature_config.yaml \
     --model_config ${CLASSIFICATION_MODEL}/tests/data/configs/model_config.yaml \


### PR DESCRIPTION
Recommanded way to train Python model is with Docker, so allow a flag to
run the integration test with Docker environment for Python to avoid the
user to maintain 2 environements.