### PR TITLE
Upgrading ml4ir version to 0.0.4 

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -16,7 +16,7 @@ def getReadMe():
 setup(
     name="ml4ir",
     packages=find_namespace_packages(include=["ml4ir.*"]),
-    version="0.0.3",
+    version="0.0.4",
     description="Machine Learning libraries for Information Retrieval",
     long_description=getReadMe(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I've bumped the ml4ir python module version to 0.0.4 and published the whl to PyPi -> https://pypi.org/project/ml4ir/