### PR TITLE
Adding tf native fns to the feature_layer

### DIFF
--- a/docs/source/api/feature_layer.rst
+++ b/docs/source/api/feature_layer.rst
@@ -17,3 +17,12 @@ Sequence Feature Transformations
    :members:
    :undoc-members:
    :show-inheritance:
+
+
+Tensorflow Native Operations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: ml4ir.base.features.feature_fns.tf_native
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/misc/changelog.md
+++ b/docs/source/misc/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2021-05-20
+
+### Added
+
+- Support for using native tf/keras feature functions from the feature config YAML
+
 ## [0.1.0] - 2021-03-01
 
 ### Changed

--- a/jvm/ml4ir-inference/scripts/generate_model.sh
+++ b/jvm/ml4ir-inference/scripts/generate_model.sh
@@ -30,7 +30,7 @@ RANKING_MODEL=ml4ir/applications/ranking
 
 $EXECUTOR ${RANKING_MODEL}/pipeline.py \
     --data_dir ${RANKING_MODEL}/tests/data/csv \
-    --feature_config ${RANKING_MODEL}/tests/data/configs/feature_config.yaml \
+    --feature_config ${RANKING_MODEL}/tests/data/configs/feature_config_integration_test.yaml \
     --run_id ${1}_ranking \
     --data_format csv \
     --execution_mode train_inference_evaluate \

--- a/jvm/ml4ir-inference/src/test/integration/ml4ir/inference/tensorflow/TensorFlowInferenceIT.scala
+++ b/jvm/ml4ir-inference/src/test/integration/ml4ir/inference/tensorflow/TensorFlowInferenceIT.scala
@@ -119,7 +119,7 @@ class TensorFlowInferenceIT extends TestData {
       )
     }
     if (query.predictedScores != null) {
-      assertArrayEquals("scores aren't close enough: ", docScores, query.predictedScores, 1e-6f)
+      assertArrayEquals("scores aren't close enough: ", docScores, query.predictedScores, 1e-4f)
     }
 
   }

--- a/jvm/ml4ir-inference/src/test/integration/ml4ir/inference/tensorflow/TensorFlowInferenceIT.scala
+++ b/jvm/ml4ir-inference/src/test/integration/ml4ir/inference/tensorflow/TensorFlowInferenceIT.scala
@@ -119,6 +119,7 @@ class TensorFlowInferenceIT extends TestData {
       )
     }
     if (query.predictedScores != null) {
+      // The success threshold was set to 1e-6f, but this was too strict. So we have updated to 1e-4f
       assertArrayEquals("scores aren't close enough: ", docScores, query.predictedScores, 1e-4f)
     }
 

--- a/python/ml4ir/applications/ranking/model/metrics/metrics_helper.py
+++ b/python/ml4ir/applications/ranking/model/metrics/metrics_helper.py
@@ -188,8 +188,8 @@ def get_grouped_stats(
             label_col=label_col,
             old_rank_col=old_rank_col,
             new_rank_col=new_rank_col,
-            group_keys=set(list(group_keys)),
-            secondary_labels=set(list(secondary_labels)),
+            group_keys=group_keys,
+            secondary_labels=secondary_labels,
         )
 
     # Select clicked records
@@ -277,7 +277,7 @@ def summarize_grouped_stats(df_grouped):
     for col in df_grouped_metrics.to_dict().keys():
         if "failure" in col:
             metric_name = col[len("mean_old_") :]
-            df_grouped_metrics["perc_improv_mean_{}".format(metric_name)] = 100. * (
+            df_grouped_metrics["perc_improv_mean_{}".format(metric_name)] = (
                 df_grouped_metrics["mean_old_{}".format(metric_name)]
                 - df_grouped_metrics["mean_new_{}".format(metric_name)]
             ) / df_grouped_metrics["mean_old_{}".format(metric_name)]

--- a/python/ml4ir/applications/ranking/model/metrics/metrics_helper.py
+++ b/python/ml4ir/applications/ranking/model/metrics/metrics_helper.py
@@ -277,7 +277,7 @@ def summarize_grouped_stats(df_grouped):
     for col in df_grouped_metrics.to_dict().keys():
         if "failure" in col:
             metric_name = col[len("mean_old_") :]
-            df_grouped_metrics["perc_improv_mean_{}".format(metric_name)] = (
+            df_grouped_metrics["perc_improv_mean_{}".format(metric_name)] = 100. * (
                 df_grouped_metrics["mean_old_{}".format(metric_name)]
                 - df_grouped_metrics["mean_new_{}".format(metric_name)]
             ) / df_grouped_metrics["mean_old_{}".format(metric_name)]

--- a/python/ml4ir/applications/ranking/model/metrics/metrics_helper.py
+++ b/python/ml4ir/applications/ranking/model/metrics/metrics_helper.py
@@ -188,8 +188,8 @@ def get_grouped_stats(
             label_col=label_col,
             old_rank_col=old_rank_col,
             new_rank_col=new_rank_col,
-            group_keys=group_keys,
-            secondary_labels=secondary_labels,
+            group_keys=set(list(group_keys)),
+            secondary_labels=set(list(secondary_labels)),
         )
 
     # Select clicked records
@@ -277,7 +277,7 @@ def summarize_grouped_stats(df_grouped):
     for col in df_grouped_metrics.to_dict().keys():
         if "failure" in col:
             metric_name = col[len("mean_old_") :]
-            df_grouped_metrics["perc_improv_mean_{}".format(metric_name)] = (
+            df_grouped_metrics["perc_improv_mean_{}".format(metric_name)] = 100. * (
                 df_grouped_metrics["mean_old_{}".format(metric_name)]
                 - df_grouped_metrics["mean_new_{}".format(metric_name)]
             ) / df_grouped_metrics["mean_old_{}".format(metric_name)]

--- a/python/ml4ir/applications/ranking/model/ranking_model.py
+++ b/python/ml4ir/applications/ranking/model/ranking_model.py
@@ -156,10 +156,10 @@ class RankingModel(RelevanceModel):
                 label_col=self.feature_config.get_label("node_name"),
                 old_rank_col=self.feature_config.get_rank("node_name"),
                 new_rank_col=RankingConstants.NEW_RANK,
-                group_keys=self.feature_config.get_group_metrics_keys(
-                    "node_name"),
-                secondary_labels=self.feature_config.get_secondary_labels(
-                    "node_name"),
+                group_keys=list(set(self.feature_config.get_group_metrics_keys(
+                    "node_name"))),
+                secondary_labels=list(set(self.feature_config.get_secondary_labels(
+                    "node_name"))),
             )
             if df_grouped_stats.empty:
                 df_grouped_stats = df_batch_grouped_stats

--- a/python/ml4ir/applications/ranking/tests/data/configs/feature_config.yaml
+++ b/python/ml4ir/applications/ranking/tests/data/configs/feature_config.yaml
@@ -66,13 +66,13 @@ features:
       args:
         ops:
           - fn: tf.math.add
-            kwargs:
+            args:
               y: 0.
           - fn: tf.math.subtract  # The goal here is to see the end-to-end functionality of tf_native_op without modifying the tests
-            kwargs:
+            args:
               y: 0.
           - fn: tf.clip_by_value
-            kwargs:
+            args:
               clip_value_min: 0.
               clip_value_max: 1000000.
     serving_info:

--- a/python/ml4ir/applications/ranking/tests/data/configs/feature_config.yaml
+++ b/python/ml4ir/applications/ranking/tests/data/configs/feature_config.yaml
@@ -64,12 +64,13 @@ features:
       shape: null
       fn: tf_native_op
       args:
-        - fn: tf.math.add
-          kwargs:
-            y: 1.
-        - fn: tf.math.subtract  # The goal here is to see the end-to-end functionality of tf_native_op without modifying the tests
-          kwargs:
-            y: 1.
+        ops:
+          - fn: tf.math.add
+            kwargs:
+              y: 1.
+          - fn: tf.math.subtract  # The goal here is to see the end-to-end functionality of tf_native_op without modifying the tests
+            kwargs:
+              y: 1.
     serving_info:
       name: pageViewsScore
       required: true

--- a/python/ml4ir/applications/ranking/tests/data/configs/feature_config.yaml
+++ b/python/ml4ir/applications/ranking/tests/data/configs/feature_config.yaml
@@ -67,10 +67,14 @@ features:
         ops:
           - fn: tf.math.add
             kwargs:
-              y: 1.
+              y: 0.
           - fn: tf.math.subtract  # The goal here is to see the end-to-end functionality of tf_native_op without modifying the tests
             kwargs:
-              y: 1.
+              y: 0.
+          - fn: tf.clip_by_value
+            kwargs:
+              clip_value_min: 0.
+              clip_value_max: 1000000.
     serving_info:
       name: pageViewsScore
       required: true

--- a/python/ml4ir/applications/ranking/tests/data/configs/feature_config.yaml
+++ b/python/ml4ir/applications/ranking/tests/data/configs/feature_config.yaml
@@ -62,6 +62,14 @@ features:
     feature_layer_info:
       type: numeric
       shape: null
+      fn: tf_native_op
+      args:
+        - fn: tf.math.add
+          kwargs:
+            y: 1.
+        - fn: tf.math.subtract  # The goal here is to see the end-to-end functionality of tf_native_op without modifying the tests
+          kwargs:
+            y: 1.
     serving_info:
       name: pageViewsScore
       required: true

--- a/python/ml4ir/applications/ranking/tests/data/configs/feature_config_integration_test.yaml
+++ b/python/ml4ir/applications/ranking/tests/data/configs/feature_config_integration_test.yaml
@@ -1,0 +1,170 @@
+query_key: 
+  name: query_id
+  node_name: query_id
+  trainable: false
+  dtype: string
+  log_at_inference: true
+  feature_layer_info:
+    type: numeric
+    shape: null
+  serving_info:
+    name: queryId
+    required: false
+    default_value: ""
+  tfrecord_type: context
+rank:
+  name: rank
+  node_name: rank
+  trainable: false
+  dtype: int64
+  log_at_inference: true
+  feature_layer_info:
+    type: numeric
+    shape: null
+  serving_info:
+    name: originalRank
+    required: true
+    default_value: 0
+  tfrecord_type: sequence
+label:
+  name: clicked
+  node_name: clicked
+  trainable: false
+  dtype: int64
+  log_at_inference: true
+  feature_layer_info:
+    type: numeric
+    shape: null
+  serving_info:
+    name: clicked
+    required: false
+    default_value: 0
+  tfrecord_type: sequence
+features:
+  - name: text_match_score
+    node_name: text_match_score
+    trainable: true
+    dtype: float
+    log_at_inference: true
+    feature_layer_info:
+      type: numeric
+      shape: null
+    serving_info:
+      name: textMatchScore
+      required: true
+      default_value: 0.0
+    tfrecord_type: sequence
+  - name: page_views_score
+    node_name: page_views_score
+    trainable: true
+    dtype: float
+    log_at_inference: true
+    feature_layer_info:
+      type: numeric
+      shape: null
+      fn: tf_native_op
+      args:
+        ops:
+          - fn: tf.math.add
+            kwargs:
+              y: 1.
+          - fn: tf.clip_by_value
+            kwargs:
+              clip_value_min: 0.
+              clip_value_max: 10.
+    serving_info:
+      name: pageViewsScore
+      required: true
+      default_value: 0.0
+    tfrecord_type: sequence
+  - name: quality_score
+    node_name: quality_score
+    trainable: true
+    dtype: float
+    log_at_inference: true
+    feature_layer_info:
+      type: numeric
+      shape: null
+    serving_info:
+      name: qualityScore
+      required: true
+      default_value: 0.0
+    tfrecord_type: sequence
+  - name: name_match
+    node_name: name_match
+    trainable: false
+    dtype: float
+    log_at_inference: true
+    is_secondary_label: true
+    feature_layer_info:
+      type: numeric
+      shape: null
+    serving_info:
+      name: nameMatch
+      required: true
+      default_value: 0.0
+    tfrecord_type: sequence
+  - name: query_text
+    node_name: query_text
+    trainable: true
+    dtype: string
+    log_at_inference: true
+    feature_layer_info:
+      type: numeric
+      shape: null
+      fn: bytes_sequence_to_encoding_bilstm
+      args:
+        encoding_type: bilstm
+        encoding_size: 128
+        embedding_size: 128
+        max_length: 20
+    preprocessing_info:
+      - fn: preprocess_text
+        args:
+          remove_punctuation: true
+          to_lower: true
+    serving_info:
+      name: q
+      required: true
+      default_value: ""
+    tfrecord_type: context
+  - name: domain_id
+    node_name: domain_id
+    trainable: true
+    dtype: int64
+    log_at_inference: true
+    is_group_metric_key: true
+    feature_layer_info:
+      type: numeric
+      shape: null
+      fn: categorical_embedding_with_indices
+      args:
+        num_buckets: 8
+        embedding_size: 64
+        default_value: null
+    serving_info:
+      name: domainID
+      required: true
+      default_value: 0
+    tfrecord_type: context
+  - name: domain_name
+    node_name: domain_name
+    trainable: true
+    dtype: string
+    log_at_inference: true
+    is_group_metric_key: true
+    feature_layer_info:
+      type: numeric
+      shape: null
+      fn: categorical_embedding_with_vocabulary_file
+      args:
+        vocabulary_file: 'ml4ir/applications/ranking/tests/data/configs/domain_name_vocab_no_id.csv'
+        embedding_size: 64
+        default_value: -1
+        num_oov_buckets: 1
+    serving_info:
+      name: domainName
+      required: true
+      default_value: ""
+    tfrecord_type: context
+  

--- a/python/ml4ir/applications/ranking/tests/data/configs/feature_config_integration_test.yaml
+++ b/python/ml4ir/applications/ranking/tests/data/configs/feature_config_integration_test.yaml
@@ -66,10 +66,10 @@ features:
       args:
         ops:
           - fn: tf.math.add
-            kwargs:
+            args:
               y: 1.
           - fn: tf.clip_by_value
-            kwargs:
+            args:
               clip_value_min: 0.
               clip_value_max: 10.
     serving_info:

--- a/python/ml4ir/applications/ranking/tests/test_feature_layer.py
+++ b/python/ml4ir/applications/ranking/tests/test_feature_layer.py
@@ -695,12 +695,12 @@ class RankingModelTest(RankingTestBase):
 
         Checks the right output shapes produced and the values generated
         """
-        input_tensor = np.random.randn(32, 4, 2)
+        input_tensor = np.abs(np.random.randn(32, 4, 2))
 
-        actual_tensor = tf.native_fns(
+        actual_tensor = tf_native_fns.tf_native_op(
                 feature_tensor=input_tensor,
                 feature_info={
-                    "name": "f"
+                    "name": "f",
                     "feature_layer_info": {
                         "args": {
                             "ops": [
@@ -712,6 +712,6 @@ class RankingModelTest(RankingTestBase):
                 },
                 file_io=None
             )
-        expected_tensor = tf.math.log(tf.math.add(input_tensor, 1.))
+        expected_tensor = tf.expand_dims(tf.math.log(tf.math.add(input_tensor, 1.)), axis=-1)
 
-        assert actual_tensor == expected_tensor
+        assert tf.reduce_all(actual_tensor == expected_tensor)

--- a/python/ml4ir/applications/ranking/tests/test_feature_layer.py
+++ b/python/ml4ir/applications/ranking/tests/test_feature_layer.py
@@ -1,9 +1,11 @@
 from ml4ir.applications.ranking.tests.test_base import RankingTestBase
 from ml4ir.base.features.feature_fns import categorical as categorical_fns
 from ml4ir.base.features.feature_fns import sequence as sequence_fns
+from ml4ir.base.features.feature_fns import tf_native as tf_native_fns
 from ml4ir.base.config.keys import SequenceExampleTypeKey
 
 import tensorflow as tf
+import numpy as np
 
 
 class RankingModelTest(RankingTestBase):
@@ -686,3 +688,30 @@ class RankingModelTest(RankingTestBase):
         except KeyError:
             found_key_error = True
         assert found_key_error
+
+    def test_tf_native_op(self):
+        """
+        Unit test the tf_native_op feature function
+
+        Checks the right output shapes produced and the values generated
+        """
+        input_tensor = np.random.randn(32, 4, 2)
+
+        actual_tensor = tf.native_fns(
+                feature_tensor=input_tensor,
+                feature_info={
+                    "name": "f"
+                    "feature_layer_info": {
+                        "args": {
+                            "ops": [
+                                {"fn": "tf.math.add", "kwargs": {"y": 1.}},
+                                {"fn": "tf.math.log"}
+                            ]
+                        }
+                    }
+                },
+                file_io=None
+            )
+        expected_tensor = tf.math.log(tf.math.add(input_tensor, 1.))
+
+        assert actual_tensor == expected_tensor

--- a/python/ml4ir/applications/ranking/tests/test_feature_layer.py
+++ b/python/ml4ir/applications/ranking/tests/test_feature_layer.py
@@ -704,7 +704,7 @@ class RankingModelTest(RankingTestBase):
                     "feature_layer_info": {
                         "args": {
                             "ops": [
-                                {"fn": "tf.math.add", "kwargs": {"y": 1.}},
+                                {"fn": "tf.math.add", "args": {"y": 1.}},
                                 {"fn": "tf.math.log"}
                             ]
                         }

--- a/python/ml4ir/applications/ranking/tests/test_metrics.py
+++ b/python/ml4ir/applications/ranking/tests/test_metrics.py
@@ -26,12 +26,12 @@ GOLD_METRICS = {'query_count': 1500.0,
                 'mean_new_name_match_failure_any_fraction': 0.153,
                 'perc_improv_ACR': -45.513,
                 'perc_improv_MRR': -23.760,
-                'perc_improv_mean_name_match_failure_all': -0.402,
-                'perc_improv_mean_name_match_failure_any': -0.964,
-                'perc_improv_mean_name_match_failure_all_rank': -0.380,
-                'perc_improv_mean_name_match_failure_any_rank': -1.244,
-                'perc_improv_mean_name_match_failure_any_count': -1.068,
-                'perc_improv_mean_name_match_failure_any_fraction': -0.754}
+                'perc_improv_mean_name_match_failure_all': -40.217,
+                'perc_improv_mean_name_match_failure_any': -96.407,
+                'perc_improv_mean_name_match_failure_all_rank': -38.028,
+                'perc_improv_mean_name_match_failure_any_rank': -124.478,
+                'perc_improv_mean_name_match_failure_any_count': -106.854,
+                'perc_improv_mean_name_match_failure_any_fraction': -75.401}
 
 
 class RankingModelTest(RankingTestBase):

--- a/python/ml4ir/applications/ranking/tests/test_serving.py
+++ b/python/ml4ir/applications/ranking/tests/test_serving.py
@@ -19,6 +19,7 @@ class RankingModelTest(RankingTestBase):
 
         # Test model training on TFRecord SequenceExample data
         data_dir = os.path.join(self.root_data_dir, "tfrecord")
+        self.feature_config_fname = "feature_config_integration_test.yaml"
         feature_config: FeatureConfig = self.get_feature_config()
 
         metrics_keys = ["categorical_accuracy"]

--- a/python/ml4ir/applications/ranking/tests/test_transfer_learning.py
+++ b/python/ml4ir/applications/ranking/tests/test_transfer_learning.py
@@ -100,7 +100,7 @@ class RankingTransferLearningTest(RankingTestBase):
             for f in glob.glob(os.path.join(self.args.models_dir, "final", "layers", "*"))
         ]
         for layer in model.model.layers:
-            assert "{}.npz".format(layer.name) in saved_layers
+            assert "{}.npz".format(layer.name.split("/")[0]) in saved_layers
 
     def test_loading_pretrained_weights(self):
         """

--- a/python/ml4ir/base/config/dynamic_args.py
+++ b/python/ml4ir/base/config/dynamic_args.py
@@ -28,6 +28,11 @@ def cast_dynamic_val(val: str):
                 # int
                 return int(val)
         elif val.isalnum():
+            # bool
+            if val.lower() == "true":
+                return True
+            elif val.lower() == "false":
+                return False
             # str
             return val
         else:

--- a/python/ml4ir/base/features/feature_fns/tf_native.py
+++ b/python/ml4ir/base/features/feature_fns/tf_native.py
@@ -1,0 +1,59 @@
+import tensorflow as tf
+
+from ml4ir.base.io.file_io import FileIO
+
+
+def tf_native_op(feature_tensor: tf.Tensor, feature_info: dict, file_io: FileIO):
+    """
+    Run a series of tensorflow native operations on the input feature tensor.
+
+    Parameters
+    ----------
+    feature_tensor : Tensor
+        Input feature tensor
+    feature_info : dict
+        Dictionary representing the configuration parameters for the specific feature from the FeatureConfig
+    file_io : FileIO object
+        FileIO handler object for reading and writing
+
+    Returns
+    -------
+    Tensor object
+        Modified feature tensor after applying all the specified ops
+
+    Notes
+    -----
+    Args under feature_layer_info:
+        list of dict
+            List of function specifications with associated arguments
+            
+            Arguments under opts:
+                fn : str
+                    Tensorflow native function name. Should start with tf.
+                    Example: tf.math.log or tf.clip_by_value
+                kwargs : dict
+                    Keyword arguments to be passed to the tensorflow function
+
+    * The functions will be applied in the order they are specified.
+    """
+    feature_node_name = feature_info.get("node_name", feature_info.get("name"))
+    tf_ops = feature_info.get("feature_layer_info", {}).get("args")
+
+    if not tf_ops:
+        return feature_tensor
+
+    for tf_op in tf_ops:
+        try:
+            fn_, kwargs = eval(tf_op["fn"]), tf_op.get("kwargs", {})
+        except AttributeError as e:
+            raise KeyError("Invalid fn specified for tf_native_op : {}\n{}".format(tf_op["fn"], e))
+        
+        try:
+            feature_tensor = fn_(feature_tensor, **kwargs)
+        except Exception as e:
+            raise Exception("Error while applying {} to {} feature:\n{}".format(tf_op["fn"], feature_node_name, e))
+
+    # Adjusting the shape to the default feature fns for concatenating in the next step
+    feature_tensor = tf.expand_dims(feature_tensor, axis=-1, name="{}_expanded".format(feature_node_name))
+
+    return feature_tensor

--- a/python/ml4ir/base/features/feature_fns/tf_native.py
+++ b/python/ml4ir/base/features/feature_fns/tf_native.py
@@ -24,7 +24,7 @@ def tf_native_op(feature_tensor: tf.Tensor, feature_info: dict, file_io: FileIO)
     Notes
     -----
     Args under feature_layer_info:
-        list of dict
+        ops: list of dict
             List of function specifications with associated arguments
             
             Arguments under opts:
@@ -37,7 +37,7 @@ def tf_native_op(feature_tensor: tf.Tensor, feature_info: dict, file_io: FileIO)
     * The functions will be applied in the order they are specified.
     """
     feature_node_name = feature_info.get("node_name", feature_info.get("name"))
-    tf_ops = feature_info.get("feature_layer_info", {}).get("args")
+    tf_ops = feature_info.get("feature_layer_info", {}).get("args", {}).get("ops", {})
 
     if not tf_ops:
         return feature_tensor

--- a/python/ml4ir/base/features/feature_fns/tf_native.py
+++ b/python/ml4ir/base/features/feature_fns/tf_native.py
@@ -6,6 +6,7 @@ from ml4ir.base.io.file_io import FileIO
 def tf_native_op(feature_tensor: tf.Tensor, feature_info: dict, file_io: FileIO):
     """
     Run a series of tensorflow native operations on the input feature tensor.
+    The functions will be applied in the order they are specified.
 
     Parameters
     ----------
@@ -31,10 +32,8 @@ def tf_native_op(feature_tensor: tf.Tensor, feature_info: dict, file_io: FileIO)
                 fn : str
                     Tensorflow native function name. Should start with tf.
                     Example: tf.math.log or tf.clip_by_value
-                kwargs : dict
+                arga : dict
                     Keyword arguments to be passed to the tensorflow function
-
-    * The functions will be applied in the order they are specified.
     """
     feature_node_name = feature_info.get("node_name", feature_info.get("name"))
     tf_ops = feature_info.get("feature_layer_info", {}).get("args", {}).get("ops", {})
@@ -44,12 +43,12 @@ def tf_native_op(feature_tensor: tf.Tensor, feature_info: dict, file_io: FileIO)
 
     for tf_op in tf_ops:
         try:
-            fn_, kwargs = eval(tf_op["fn"]), tf_op.get("kwargs", {})
+            fn_, fn_args = eval(tf_op["fn"]), tf_op.get("args", {})
         except AttributeError as e:
             raise KeyError("Invalid fn specified for tf_native_op : {}\n{}".format(tf_op["fn"], e))
         
         try:
-            feature_tensor = fn_(feature_tensor, **kwargs)
+            feature_tensor = fn_(feature_tensor, **fn_args)
         except Exception as e:
             raise Exception("Error while applying {} to {} feature:\n{}".format(tf_op["fn"], feature_node_name, e))
 

--- a/python/ml4ir/base/features/feature_fns/tf_native.py
+++ b/python/ml4ir/base/features/feature_fns/tf_native.py
@@ -54,6 +54,6 @@ def tf_native_op(feature_tensor: tf.Tensor, feature_info: dict, file_io: FileIO)
             raise Exception("Error while applying {} to {} feature:\n{}".format(tf_op["fn"], feature_node_name, e))
 
     # Adjusting the shape to the default feature fns for concatenating in the next step
-    feature_tensor = tf.expand_dims(feature_tensor, axis=-1, name="{}_expanded".format(feature_node_name))
+    feature_tensor = tf.expand_dims(feature_tensor, axis=-1, name="{}_tf_native_op".format(feature_node_name))
 
     return feature_tensor

--- a/python/ml4ir/base/features/feature_fns/tf_native.py
+++ b/python/ml4ir/base/features/feature_fns/tf_native.py
@@ -32,7 +32,7 @@ def tf_native_op(feature_tensor: tf.Tensor, feature_info: dict, file_io: FileIO)
                 fn : str
                     Tensorflow native function name. Should start with tf.
                     Example: tf.math.log or tf.clip_by_value
-                arga : dict
+                args : dict
                     Keyword arguments to be passed to the tensorflow function
     """
     feature_node_name = feature_info.get("node_name", feature_info.get("name"))

--- a/python/ml4ir/base/features/feature_layer.py
+++ b/python/ml4ir/base/features/feature_layer.py
@@ -12,6 +12,7 @@ from ml4ir.base.features.feature_fns.categorical import categorical_embedding_wi
 from ml4ir.base.features.feature_fns.categorical import (
     categorical_embedding_with_vocabulary_file_and_dropout,
 )
+from ml4ir.base.features.feature_fns.tf_native import tf_native_op
 from ml4ir.base.io.file_io import FileIO
 
 
@@ -30,6 +31,7 @@ class FeatureLayerMap:
             categorical_embedding_with_indices.__name__: categorical_embedding_with_indices,
             categorical_embedding_with_vocabulary_file.__name__: categorical_embedding_with_vocabulary_file,
             categorical_embedding_with_vocabulary_file_and_dropout.__name__: categorical_embedding_with_vocabulary_file_and_dropout,
+            tf_native_op.__name__: tf_native_op
         }
 
     def add_fn(self, key, fn):

--- a/python/setup.py
+++ b/python/setup.py
@@ -16,7 +16,7 @@ def getReadMe():
 setup(
     name="ml4ir",
     packages=find_namespace_packages(include=["ml4ir.*"]),
-    version="0.1.0",
+    version="0.1.1",
     description="Machine Learning libraries for Information Retrieval",
     long_description=getReadMe(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Adding support for using native tensorflow feature fns such as `tf.math.log` from the `feature_config` YAML. This allows us to embed such ops within the tf graph and thereby the SavedModel without writing a separate wrapper function for each.

Example feature config:
```
    feature_layer_info:
      type: numeric
      fn: tf_native_op
      args:
        ops:
          - fn: tf.math.add
            kwargs:
              y: 1.
          - fn: tf.math.log
 ```
 The above function does a natural log of the input tensor after shifting it by 1.
 
 Other minor fixes:
 - Fixing percentage metric by doing `* 100.`
 - Fixing dynamic args with booleans