### PR TITLE
Update e2e test script to rebuild the docker image to avoid stale files

### DIFF
--- a/jvm/ml4ir-inference/scripts/generate_model.sh
+++ b/jvm/ml4ir-inference/scripts/generate_model.sh
@@ -13,6 +13,8 @@ if [ -z "$2" ]
     export PYTHONPATH=.
     EXECUTOR="python"
 else
+  # docker-build to ensure to get all the local modifications tested
+  docker-compose build
   EXECUTOR="docker-compose run ml4ir python"
 fi
 

--- a/python/docker-compose.yml
+++ b/python/docker-compose.yml
@@ -11,5 +11,6 @@ services:
       - ./logs:/home/ml4ir/python/logs
       - ./data:/home/ml4ir/python/data
       - ./models:/home/ml4ir/python/models
+      - ./ml4ir/:/home/ml4ir/python/ml4ir
     tty: true # uncomment for python debugging
     stdin_open: true # uncomment for python debugging

--- a/python/docker-compose.yml
+++ b/python/docker-compose.yml
@@ -11,6 +11,5 @@ services:
       - ./logs:/home/ml4ir/python/logs
       - ./data:/home/ml4ir/python/data
       - ./models:/home/ml4ir/python/models
-      - ./ml4ir/:/home/ml4ir/python/ml4ir
     tty: true # uncomment for python debugging
     stdin_open: true # uncomment for python debugging

--- a/python/ml4ir/build/Dockerfile
+++ b/python/ml4ir/build/Dockerfile
@@ -14,11 +14,10 @@ RUN pip config set global.extra-index-url https://pypi.python.org/simple
 RUN pip install --upgrade setuptools
 RUN pip install -r requirements.txt
 
-# Copy ml4ir
-COPY . /home/ml4ir/python/
+# Copy docker entrypoint
+COPY ml4ir/build/run_driver.sh $PYTHONPATH/.
 
 # Set docker entrypoint
-RUN cp $PYTHONPATH/ml4ir/build/run_driver.sh $PYTHONPATH/.
 RUN chmod +x run_driver.sh
 
 ENTRYPOINT ["./run_driver.sh"]

--- a/python/ml4ir/build/Dockerfile
+++ b/python/ml4ir/build/Dockerfile
@@ -14,10 +14,11 @@ RUN pip config set global.extra-index-url https://pypi.python.org/simple
 RUN pip install --upgrade setuptools
 RUN pip install -r requirements.txt
 
-# Copy docker entrypoint
-COPY ml4ir/build/run_driver.sh $PYTHONPATH/.
+# Copy ml4ir
+COPY . /home/ml4ir/python/
 
 # Set docker entrypoint
+RUN cp $PYTHONPATH/ml4ir/build/run_driver.sh $PYTHONPATH/.
 RUN chmod +x run_driver.sh
 
 ENTRYPOINT ["./run_driver.sh"]


### PR DESCRIPTION
This allows to keep in sync the test files for integration tests