### PR TITLE
Adding L1, L2 coefficients to positional bias weight initialization

### DIFF
--- a/python/ml4ir/applications/ranking/tests/test_fixed_additive_positional_bias.py
+++ b/python/ml4ir/applications/ranking/tests/test_fixed_additive_positional_bias.py
@@ -5,6 +5,7 @@ from ml4ir.base.model.architectures.fixed_additive_positional_bias import FixedA
 
 warnings.filterwarnings("ignore")
 
+INPUT_DIR = "/ml4ir/applications/ranking/tests/data/configs"
 
 class TestFixedAdditivePositionalBias(unittest.TestCase):
 
@@ -25,6 +26,14 @@ class TestFixedAdditivePositionalBias(unittest.TestCase):
         self.apply_additive_positional_bias([1,2], 2, True)
         self.apply_additive_positional_bias([2], 2, False)
         self.apply_additive_positional_bias([2,4,6,8], 10, True)
+
+    def test_weight_initialization(self):
+        """Testing weight initializations to zeros"""
+        positional_bias = FixedAdditivePositionalBias(max_ranks=5, kernel_initializer='Zeros')
+        positional_bias(tf.constant([1.]))
+        weights = positional_bias.dense.get_weights()
+        assert all([w == 0. for w in weights[0]])
+
 
 
 if __name__ == "__main__":

--- a/python/ml4ir/applications/ranking/tests/test_fixed_additive_positional_bias.py
+++ b/python/ml4ir/applications/ranking/tests/test_fixed_additive_positional_bias.py
@@ -27,12 +27,19 @@ class TestFixedAdditivePositionalBias(unittest.TestCase):
         self.apply_additive_positional_bias([2], 2, False)
         self.apply_additive_positional_bias([2,4,6,8], 10, True)
 
-    def test_weight_initialization(self):
+    def test_zeros_weight_initialization(self):
         """Testing weight initializations to zeros"""
         positional_bias = FixedAdditivePositionalBias(max_ranks=5, kernel_initializer='Zeros')
         positional_bias(tf.constant([1.]))
         weights = positional_bias.dense.get_weights()
         assert all([w == 0. for w in weights[0]])
+
+    def test_non_zeros_weight_initialization(self):
+        """Testing weight initializations to non zeros"""
+        positional_bias = FixedAdditivePositionalBias(max_ranks=5, kernel_initializer='glorot_uniform')
+        positional_bias(tf.constant([1.]))
+        weights = positional_bias.dense.get_weights()
+        assert any([w != 0. for w in weights[0]])
 
 
 

--- a/python/ml4ir/base/model/architectures/dnn.py
+++ b/python/ml4ir/base/model/architectures/dnn.py
@@ -28,7 +28,10 @@ class DNN:
         self.layer_ops: List = self.define_architecture(model_config, feature_config)
         if 'positional_bias_handler' in self.model_config and self.model_config['positional_bias_handler'][
             'key'] == PositionalBiasHandler.FIXED_ADDITIVE_POSITIONAL_BIAS:
-            self.positional_bias_layer = FixedAdditivePositionalBias(max_ranks=self.model_config['positional_bias_handler']['max_ranks'])
+            self.positional_bias_layer = FixedAdditivePositionalBias(max_ranks=self.model_config['positional_bias_handler']['max_ranks'],
+                                                                     kernel_initializer=self.model_config['positional_bias_handler'].get('kernel_initializer', 'Zeros'),
+                                                                     l1_coeff=self.model_config['positional_bias_handler'].get('l1_coeff', 0),
+                                                                     l2_coeff=self.model_config['positional_bias_handler'].get('l2_coeff', 0))
 
     def define_architecture(self, model_config: dict, feature_config: FeatureConfig):
         """

--- a/python/ml4ir/base/model/architectures/fixed_additive_positional_bias.py
+++ b/python/ml4ir/base/model/architectures/fixed_additive_positional_bias.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 from tensorflow.keras import layers
 from ml4ir.applications.ranking.config.keys import PositionalBiasHandler
-from tensorflow.keras import regularizers, initializers
+from tensorflow.keras import regularizers
 
 
 class FixedAdditivePositionalBias(layers.Layer):
@@ -32,7 +32,6 @@ class FixedAdditivePositionalBias(layers.Layer):
                      kernel_regularizer=regularizers.l1_l2(l1=l1_coeff, l2=l2_coeff),
                      activation=None,
                      use_bias=False)
-        assert type(self.dense.kernel_initializer) == type(initializers.get(kernel_initializer))
         self.max_ranks = max_ranks
 
     def call(self, inputs, training=False):

--- a/python/ml4ir/base/model/architectures/fixed_additive_positional_bias.py
+++ b/python/ml4ir/base/model/architectures/fixed_additive_positional_bias.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 from tensorflow.keras import layers
 from ml4ir.applications.ranking.config.keys import PositionalBiasHandler
-from tensorflow.keras import regularizers
+from tensorflow.keras import regularizers, initializers
 
 
 class FixedAdditivePositionalBias(layers.Layer):
@@ -32,6 +32,7 @@ class FixedAdditivePositionalBias(layers.Layer):
                      kernel_regularizer=regularizers.l1_l2(l1=l1_coeff, l2=l2_coeff),
                      activation=None,
                      use_bias=False)
+        assert type(self.dense.kernel_initializer) == type(initializers.get(kernel_initializer))
         self.max_ranks = max_ranks
 
     def call(self, inputs, training=False):

--- a/python/ml4ir/base/model/architectures/fixed_additive_positional_bias.py
+++ b/python/ml4ir/base/model/architectures/fixed_additive_positional_bias.py
@@ -1,6 +1,7 @@
 import tensorflow as tf
 from tensorflow.keras import layers
 from ml4ir.applications.ranking.config.keys import PositionalBiasHandler
+from tensorflow.keras import regularizers
 
 
 class FixedAdditivePositionalBias(layers.Layer):
@@ -23,10 +24,12 @@ class FixedAdditivePositionalBias(layers.Layer):
 
     Where x is the maximum number of documents per query.
     """
-    def __init__(self, max_ranks):
+    def __init__(self, max_ranks, kernel_initializer='Zeros', l1_coeff=0, l2_coeff=0):
         super(FixedAdditivePositionalBias, self).__init__()
         self.dense = layers.Dense(1,
                      name=PositionalBiasHandler.FIXED_ADDITIVE_POSITIONAL_BIAS,
+                     kernel_initializer=kernel_initializer,
+                     kernel_regularizer=regularizers.l1_l2(l1=l1_coeff, l2=l2_coeff),
                      activation=None,
                      use_bias=False)
         self.max_ranks = max_ranks


### PR DESCRIPTION
Example
`
positional_bias_handler:
  key: fixed_additive_positional_bias
  max_ranks: 25
  kernel_initializer: Zeros
  l1_coeff: 0.1
  l2_coeff: 0.1

`