### PR TITLE
Updating tensorflow jvm

### DIFF
--- a/jvm/ml4ir-inference/pom.xml
+++ b/jvm/ml4ir-inference/pom.xml
@@ -150,6 +150,9 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <addScalacArgs>-target:jvm-1.8</addScalacArgs>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -214,7 +217,7 @@
   <dependencies>
     <dependency>
       <groupId>org.tensorflow</groupId>
-      <artifactId>tensorflow</artifactId>
+      <artifactId>tensorflow-core-platform</artifactId>
     </dependency>
     <dependency>
       <groupId>org.tensorflow</groupId>
@@ -222,8 +225,13 @@
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.21.12</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>3.11.4</version>
+      <version>3.21.12</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/TFRecordExecutor.scala
+++ b/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/TFRecordExecutor.scala
@@ -1,70 +1,60 @@
 package ml4ir.inference.tensorflow
 
 import com.google.protobuf.MessageLite
-import org.tensorflow.{SavedModelBundle, Tensor, Tensors}
+import org.tensorflow.ndarray.{ByteNdArray, NdArray, NdArrays, Shape, StdArrays}
+import org.tensorflow.ndarray.buffer.{ByteDataBuffer, DataBuffers}
+import org.tensorflow.types.{TFloat32, TString}
+import org.tensorflow.{SavedModelBundle, Tensor}
 
 /**
-  * @see <a href="https://www.tensorflow.org/api_docs/java/reference/org/tensorflow/SavedModelBundle">SavedModelBundle</a>
-  * Base class for performing the actual Tensorflow execution {@see TFRecordExecutor#apply}
-  *
-  * @param dirPath location on local disk of the Tensorflow { @code SavedModelBundle} to be used for inference
-  *                Directory likely looks like:
-  *                model_bundle/
-  *                ├── assets
-  *                ├── saved_model.pb
-  *                └── variables
-  *                    ├── variables.data-00000-of-00001
-  *                    ├── variables.data-00000-of-00002
-  *                    ├── variables.data-00001-of-00002
-  *                    └── variables.index
-  * @param config instantiated struct with the values from the feature_config.yaml relevant for inference
-  */
+ * @see <a href="https://www.tensorflow.org/api_docs/java/reference/org/tensorflow/SavedModelBundle">SavedModelBundle</a>
+ * Base class for performing the actual Tensorflow execution {@see TFRecordExecutor#apply}
+ *
+ * @param dirPath location on local disk of the Tensorflow { @code SavedModelBundle} to be used for inference
+ *                Directory likely looks like:
+ *                model_bundle/
+ *                ├── assets
+ *                ├── saved_model.pb
+ *                └── variables
+ *                    ├── variables.data-00000-of-00001
+ *                    ├── variables.data-00000-of-00002
+ *                    ├── variables.data-00001-of-00002
+ *                    └── variables.index
+ * @param config instantiated struct with the values from the feature_config.yaml relevant for inference
+ */
 class TFRecordExecutor(dirPath: String, config: ModelExecutorConfig) {
   private val savedModelBundle = SavedModelBundle.load(dirPath, "serve")
   private val session = savedModelBundle.session()
-
   /**
-    * To serialize the protobuf input into a byte[] as input to the Tensorflow graph
-    * @param in Should be either a { @see org.tensorflow.example.Example} or { @see org.tensorflow.SequenceExample},
-    *           likely constructed by { @see ExampleBuilder} or { @see SequenceExampleBuilder} respectively
-    * @return serialized bytes of the protobuf, as specified by the {@code MessageLite} interface
-    */
+   * To serialize the protobuf input into a byte[] as input to the Tensorflow graph
+   * @param in Should be either a { @see org.tensorflow.example.Example} or { @see org.tensorflow.SequenceExample},
+   *           likely constructed by { @see ExampleBuilder} or { @see SequenceExampleBuilder} respectively
+   * @return serialized bytes of the protobuf, as specified by the {@code MessageLite} interface
+   */
   def serializeToBytes(in: MessageLite): Array[Byte] = in.toByteArray
-
   /**
-    *
-    * @param in
-    * @return
-    */
+   *
+   * @param in
+   * @return
+   */
   def apply(in: MessageLite): Array[Float] = {
     val ModelExecutorConfig(inputNode, outputNode) = config
     // TF typically runs the forward pass on batches, so we wrap our protobuf bytes in another outer length-1 array
-    val inputTensor: Tensor[String] = Tensors.create(Array(serializeToBytes(in)))
+    val inputTensor: TString = TString.tensorOfBytes(NdArrays.vectorOfObjects(serializeToBytes(in)))
+
     try {
-      val resultTensor: Tensor[_] = session
+      val resultTensor: TFloat32 = session
         .runner()
         .feed(inputNode, inputTensor)
         .fetch(outputNode)
         .run()
         .get(0)
-      resultTensor.shape().length match {
-        case 1 =>
-          val predictions: Array[Float] = Array.ofDim[Float](resultTensor.shape()(0).toInt)
-          resultTensor.copyTo(predictions)
-          predictions
-        case 2 =>
-          val predictions: Array[Array[Float]] =
-            Array.ofDim[Float](resultTensor.shape()(0).toInt, resultTensor.shape()(1).toInt)
-          resultTensor.copyTo(predictions)
-          predictions(0)
-        case 3 =>
-          val predictions: Array[Array[Array[Float]]] =
-            Array
-              .ofDim[Float](resultTensor.shape()(0).toInt, resultTensor.shape()(1).toInt, resultTensor.shape()(2).toInt)
-          resultTensor.copyTo(predictions)
-          predictions(0)(0)
-        case _ =>
-          throw new IllegalArgumentException("unsupported result shape: " + resultTensor.shape())
+        .asInstanceOf[TFloat32]
+      resultTensor.shape().numDimensions() match {
+        case 1 => StdArrays.array1dCopyOf(resultTensor)
+        case 2 => StdArrays.array2dCopyOf(resultTensor)(0)
+        case 3 => StdArrays.array3dCopyOf(resultTensor)(0)(0)
+        case _ => throw new IllegalArgumentException("unsupported result shape: " + resultTensor.shape())
       }
     } finally {
       inputTensor.close()

--- a/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/data/FeaturePreprocessor.scala
+++ b/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/data/FeaturePreprocessor.scala
@@ -1,73 +1,69 @@
 package ml4ir.inference.tensorflow.data
 
-import org.tensorflow.DataType
+import org.tensorflow.proto.framework.DataType
 
 /**
-  * Wrapper class which uses the ModelFeatures configuration to filter to the allowed features, map from
-  * "serving name" to their tensorflow node name, and fill in with defaults when required.
-  *
-  * Also encapsulates three provided extractor functions from input type T: (t, featureName) => Float, Long, String
-  * and turns the whole thing into a feature extractor function: T => Example
-  *
-  * By construction, this class will have no idea about unknown features which the input T *could* provide, so there
-  * is no callback to log this information.  Possible TODO: log features expected by the config, when defaults used.
-  *
-  * @tparam T for example: Map[String, String]
-  */
+ * Wrapper class which uses the ModelFeatures configuration to filter to the allowed features, map from
+ * "serving name" to their tensorflow node name, and fill in with defaults when required.
+ *
+ * Also encapsulates three provided extractor functions from input type T: (t, featureName) => Float, Long, String
+ * and turns the whole thing into a feature extractor function: T => Example
+ *
+ * By construction, this class will have no idea about unknown features which the input T *could* provide, so there
+ * is no callback to log this information.  Possible TODO: log features expected by the config, when defaults used.
+ *
+ * @tparam T for example: Map[String, String]
+ */
 class FeaturePreprocessor[T](featuresConfig: FeaturesConfig,
                              floatExtractor: String => (T => Option[Float]),
                              longExtractor: String => (T => Option[Long]),
                              stringExtractor: String => (T => Option[String]),
                              primitiveProcessors: Map[DataType, Map[String, PrimitiveProcessor]] =
-                               Map.empty.withDefaultValue(Map.empty.withDefaultValue(PrimitiveProcessor())))
-    extends (T => MultiFeatures) {
+                             Map.empty.withDefaultValue(Map.empty.withDefaultValue(PrimitiveProcessor())))
+  extends (T => MultiFeatures) {
   val processors: Map[DataType, Map[String, PrimitiveProcessor]] = primitiveProcessors
     .mapValues(_.withDefaultValue(PrimitiveProcessor()))
     .withDefaultValue(Map.empty.withDefaultValue(PrimitiveProcessor()))
-
   /**
-    *
-    * @param t object which will have its features extracted into an Example
-    * @return the feature-ized Example object
-    */
+   *
+   * @param t object which will have its features extracted into an Example
+   * @return the feature-ized Example object
+   */
   override def apply(t: T): MultiFeatures =
     MultiFeatures.apply(extractFloatFeatures(t), extractLongFeatures(t), extractStringFeatures(t))
 
   private[this] def extractFloatFeatures(t: T): Map[String, Float] =
-    featuresConfig(DataType.FLOAT)
+    featuresConfig(DataType.DT_FLOAT)
       .map {
         case (servingName, NodeWithDefault(nodeName, defaultValue)) =>
-          nodeName -> processors(DataType.FLOAT)(servingName)
+          nodeName -> processors(DataType.DT_FLOAT)(servingName)
             .processFloat(floatExtractor(servingName)(t).getOrElse(defaultValue.toFloat))
       }
 
   private[this] def extractLongFeatures(t: T): Map[String, Long] =
-    featuresConfig(DataType.INT64)
+    featuresConfig(DataType.DT_INT64)
       .map {
         case (servingName, NodeWithDefault(nodeName, defaultValue)) =>
-          nodeName -> processors(DataType.INT64)(servingName)
+          nodeName -> processors(DataType.DT_INT64)(servingName)
             .processLong(longExtractor(servingName)(t).getOrElse(defaultValue.toLong))
       }
   private[this] def extractStringFeatures(t: T): Map[String, String] =
-    featuresConfig(DataType.STRING)
+    featuresConfig(DataType.DT_STRING)
       .map {
         case (servingName: String, NodeWithDefault(nodeName, defaultValue)) =>
-          nodeName -> processors(DataType.STRING)(servingName)
+          nodeName -> processors(DataType.DT_STRING)(servingName)
             .processString(stringExtractor(servingName)(t).getOrElse(defaultValue))
       }
 }
-
 /**
-  * Simple wrapper class for overriding Float=>Float, Long=Long, and String=>String processing. Default is NOOP.
-  */
+ * Simple wrapper class for overriding Float=>Float, Long=Long, and String=>String processing. Default is NOOP.
+ */
 case class PrimitiveProcessor() {
   def processFloat(f: Float): Float = f
   def processLong(l: Long): Long = l
   def processString(s: String): String = s
 }
-
 object PrimitiveProcessors {
-
   def fromFunctionMaps(featuresConfig: FeaturesConfig,
                        tfRecordType: String,
                        fFuncs: Map[String, Float => Float],
@@ -76,22 +72,22 @@ object PrimitiveProcessors {
     featuresConfig
       .mapValues(mapping => mapping.withDefaultValue(PrimitiveProcessor()))
       .map {
-        case (DataType.FLOAT, nodeMap) =>
-          DataType.FLOAT -> nodeMap.map {
+        case (DataType.DT_FLOAT, nodeMap) =>
+          DataType.DT_FLOAT -> nodeMap.map {
             case (feature, _) =>
               feature -> new PrimitiveProcessor() { override def processFloat(f: Float): Float = fFuncs(feature)(f) }
           }
-        case (DataType.INT64, nodeMap) =>
-          DataType.INT64 -> nodeMap.map {
+        case (DataType.DT_INT64, nodeMap) =>
+          DataType.DT_INT64 -> nodeMap.map {
             case (feature, _) =>
               feature -> new PrimitiveProcessor() { override def processLong(l: Long): Long = lFuncs(feature)(l) }
           }
-        case (DataType.STRING, nodeMap) =>
-          DataType.STRING -> nodeMap.map {
+        case (DataType.DT_STRING, nodeMap) =>
+          DataType.DT_STRING -> nodeMap.map {
             case (feature, _) =>
               feature -> new PrimitiveProcessor() { override def processString(s: String): String = sFuncs(feature)(s) }
           }
-        case (dt: DataType, _) =>
+        case (dt, _) =>
           throw new UnsupportedOperationException(s"invalid data type in config: $dt")
       }
   }

--- a/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/data/FeatureProcessors.scala
+++ b/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/data/FeatureProcessors.scala
@@ -7,7 +7,8 @@ import scala.collection.JavaConverters._
 import java.util.function.{Function => JFunction}
 
 import ml4ir.inference.tensorflow.data.FeaturesConfigHelper._
-import org.tensorflow.DataType
+import org.tensorflow.proto.framework.DataType
+import org.tensorflow.types.family.TType
 
 object FeatureProcessors {
   val simpleFloatExtractor: String => (JMap[String, String] => Option[Float]) =

--- a/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/data/ModelFeaturesConfig.scala
+++ b/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/data/ModelFeaturesConfig.scala
@@ -9,7 +9,9 @@ import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.google.common.base.Charsets._
 import com.google.common.io.Files
-import org.tensorflow.DataType
+import org.tensorflow.proto.framework.DataType
+import org.tensorflow.types.{TFloat32, TInt64, TString}
+import org.tensorflow.types.family.TType
 
 import scala.collection.JavaConverters._
 
@@ -46,7 +48,16 @@ case class FeatureConfig(@JsonProperty("name") name: String,
                          @JsonProperty("dtype") dTypeString: String,
                          @JsonProperty("serving_info") servingConfig: ServingConfig,
                          @JsonProperty("tfrecord_type") tfRecordType: String) {
-  def dType: DataType = DataType.valueOf(dTypeString.toUpperCase)
+  def dType: DataType = {
+    dTypeString.toUpperCase match {
+      case "INT" => DataType.DT_INT64
+      case "INT64" => DataType.DT_INT64
+      case "FLOAT" => DataType.DT_FLOAT
+      case "FLOAT32" => DataType.DT_FLOAT
+      case "BYTES" => DataType.DT_STRING
+      case "STRING" => DataType.DT_STRING
+    }
+  }
 }
 
 /**

--- a/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/data/package.scala
+++ b/jvm/ml4ir-inference/src/main/scala/ml4ir/inference/tensorflow/data/package.scala
@@ -1,6 +1,6 @@
 package ml4ir.inference.tensorflow
 
-import org.tensorflow.DataType
+import org.tensorflow.proto.framework.DataType
 
 package object data {
   type ServingNodeMapping = Map[String, NodeWithDefault]

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ml4ir</groupId>
   <artifactId>ml4ir-parent</artifactId>
-  <version>0.0.3-SNAPSHOT</version>
+  <version>0.0.5-SNAPSHOT</version>
   <name>ml4ir-parent</name>
   <packaging>pom</packaging>
 

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ml4ir</groupId>
   <artifactId>ml4ir-parent</artifactId>
-  <version>0.0.5-SNAPSHOT</version>
+  <version>0.0.3-SNAPSHOT</version>
   <name>ml4ir-parent</name>
   <packaging>pom</packaging>
 

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -12,7 +12,8 @@
     <scalastyle.version>0.7.0</scalastyle.version>
     <scala.version>2.11.12</scala.version>
     <scala.artifact.suffix>2.11</scala.artifact.suffix>
-    <tensorflow.version>1.15.0</tensorflow.version>
+    <tensorflow.core.version>0.4.2</tensorflow.core.version>
+    <tensorflow.proto.version>1.15.0</tensorflow.proto.version>
     <jackson.version>2.10.0</jackson.version>
   </properties>
 
@@ -47,13 +48,13 @@
     </dependency>
     <dependency>
         <groupId>org.tensorflow</groupId>
-        <artifactId>tensorflow</artifactId>
-        <version>${tensorflow.version}</version>
+        <artifactId>tensorflow-core-platform</artifactId>
+        <version>${tensorflow.core.version}</version>
     </dependency>
     <dependency>
       <groupId>org.tensorflow</groupId>
       <artifactId>proto</artifactId>
-      <version>${tensorflow.version}</version>
+      <version>${tensorflow.proto.version}</version>
     </dependency>
       <dependency>
           <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
This PR isolates the changes to upgrade the `ml4ir-inference` tensorflow jars to the latest serving libraries available. 

**Note** -> I've deliberately filed this PR against `master` to show that this new version can serve models trained on the old tensorflow==2.0.4 python stack.