### PR TITLE
Masking -inf, inf in rank match failure computation

### DIFF
--- a/python/ml4ir/applications/ranking/model/metrics/aux_metrics_impl.py
+++ b/python/ml4ir/applications/ranking/model/metrics/aux_metrics_impl.py
@@ -5,8 +5,6 @@ from tensorflow.keras import metrics
 
 class RankMatchFailure(metrics.Mean):
     """Custom metric implementation to compute the ranking performance on an auxiliary label"""
-    def __init__(self, name):
-        self.name = name
 
     def update_state(self, y_true, y_pred, y_aux, y_true_ranks, mask, sample_weight=None):
         """
@@ -162,7 +160,6 @@ class RankMatchFailure(metrics.Mean):
         idxs = tf.expand_dims(tf.range(tf.shape(ranks)[0]), -1)
         y_true_click_ranks = tf.expand_dims(tf.cast(y_true_click_ranks, tf.int32), axis=-1)
         y_true_click_idx = tf.where(y_true_click_ranks > 0, y_true_click_ranks - 1, 0)
-
         clicked_records_score = tf.gather_nd(
             y_aux, indices=tf.concat([idxs, y_true_click_idx], axis=-1)
         )

--- a/python/ml4ir/applications/ranking/tests/test_rank_match_failure.py
+++ b/python/ml4ir/applications/ranking/tests/test_rank_match_failure.py
@@ -70,6 +70,25 @@ class RankMachFailureTest(tf.test.TestCase):
         )
         assert np.isclose(actual_dcg, expected_dcg).all()
 
+    def test__mask_inf_scores(self):
+        """Test masking inf, -inf for a given vector"""
+        tf_Vec = tf.constant(
+            [
+                0.0,
+                4.0,
+                np.inf,
+                np.inf,
+                -np.inf,
+                4.0,
+                -np.inf,
+            ]
+        )
+        expected_vec = tf.constant(
+            [0, 4, 0, 0, 0, 4, 0]
+        )
+        masked_vec = RankMatchFailure._mask_inf_scores(tf_Vec)
+        self.assertAllClose(masked_vec, expected_vec, atol=1e-04)
+
     def test__compute_match_failure(self):
         y_true_click_rank = tf.constant(
             [


### PR DESCRIPTION
There was a bug where an inf value gets multiplied by zero resulting in a nan computation.