### PR TITLE
Optimize predictions in classification_model.py to prevent OOM error

### DIFF
--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -194,8 +194,15 @@ class ClassificationModel(RelevanceModel):
         
         metric.reset_states()
         for chunk in self.get_chunks_from_df(predictions, batch_size):
-            metric.update_state(tf.constant(chunk[label_name].values.tolist(), dtype=tf.float32),
-                                tf.constant(chunk[output_name].values.tolist(), dtype=tf.float32))
+            y_true = tf.constant(chunk[label_name].values.tolist(), dtype=tf.float32)
+            y_pred = tf.constant(chunk[output_name].values.tolist(), dtype=tf.float32)
+        
+            # Ensure y_pred is 2D
+            if len(y_pred.shape) == 1:
+                y_pred = tf.expand_dims(y_pred, axis=-1)
+            
+            metric.update_state(y_true, y_pred)
+
         if group_name:
             return {"group_name": group_name,
                     "group_key": group_key,

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -110,8 +110,7 @@ class ClassificationModel(RelevanceModel):
                                         inference_signature=inference_signature,
                                         additional_features=additional_features,
                                         logs_dir=logs_dir,
-                                        logging_frequency=logging_frequency,
-                                        batch_size = batch_size):
+                                        logging_frequency=logging_frequency):
                 for metric in self.model.metrics:
                     global_metrics.append(
                         self.calculate_metric_on_batch(metric, predictions, batch_size))

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -89,6 +89,7 @@ class ClassificationModel(RelevanceModel):
                                 "With large test datasets, it can lead in OOM issues.")
             
             # Concatenating all batches returned by predict method into one dataframe to compute metrics
+            # TODO: find a way to calculate metrics without the need of operating on all predictions at once as this can lead to OOM error
             predictions = pd.concat(self.predict(test_dataset, 
                                         inference_signature=inference_signature,
                                         additional_features=additional_features,

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -1,3 +1,4 @@
+import ast
 import os
 import sys
 from typing import Optional

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -165,7 +165,7 @@ class ClassificationModel(RelevanceModel):
         for pos in range(0, len(dataframe), size):
             yield dataframe.iloc[pos:pos + size]
 
-    def _convert_string_to_array(s):
+    def _convert_string_to_array(self, s):
         try:
             # Add commas between numbers to make it a valid Python list
             s_fixed = re.sub(r"\s+", ",", s.strip())

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -256,6 +256,7 @@ class ClassificationModel(RelevanceModel):
             
         for batch_idx, (batch, label) in enumerate(test_dataset.prefetch(tf.data.experimental.AUTOTUNE)):
             if batch_idx % logging_frequency == 0: print(f"Processing predictions : Batch {batch_idx}")
+            print("test label", len(label))
             predictions_batch = self.model.predict(batch)
             batch_df = self._create_prediction_dataframe(logging_frequency, (batch,label))
             batch_df[self.output_name] = [x for x in np.squeeze(predictions_batch[self.output_name])]

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -245,8 +245,6 @@ class ClassificationModel(RelevanceModel):
             self.file_io.rm_file(outfile)
             
         for batch_idx, (batch, label) in enumerate(test_dataset.prefetch(tf.data.experimental.AUTOTUNE)):
-            if batch_idx % logging_frequency == 0: print(f"Processing predictions : Batch {batch_idx}")
-            print("test label", len(label))
             predictions_batch = self.model.predict(batch)
             batch_df = self._create_prediction_dataframe(logging_frequency, (batch,label))
             batch_df[self.output_name] = [x for x in np.squeeze(predictions_batch[self.output_name])]
@@ -264,6 +262,8 @@ class ClassificationModel(RelevanceModel):
                     if isinstance(batch_df[col].values[0], bytes):
                         batch_df[col] = batch_df[col].str.decode('utf8')
                 batch_df.to_csv(outfile, mode="a", header=batch_idx==0, index=False)
+            if batch_idx % logging_frequency == 0: 
+                print(f"Finished predicting scores for {batch_idx} batches")
             yield batch_df
 
     def _create_prediction_dataframe(self, logging_frequency, test_dataset):

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -264,7 +264,7 @@ class ClassificationModel(RelevanceModel):
                 batch_df.to_csv(outfile, mode="a", header=batch_idx==0, index=False)
                 
             if batch_idx % logging_frequency == 0: 
-                self.logger.info((f"Finished predicting scores for {batch_idx} batches")
+                self.logger.info(f"Finished predicting scores for {batch_idx} batches")
             yield batch_df
                 
         if logs_dir: self.logger.info(f"Model predictions written to: {outfile}")

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -106,7 +106,7 @@ class ClassificationModel(RelevanceModel):
             '''
             batch_size = test_dataset._input_dataset._batch_size.numpy()  # Hacky way to get batch_size
             # Letting metrics in the outer loop to avoid tracing
-            for prediction in self.predict(test_dataset, inference_signature=inference_signature,
+            for predictions in self.predict(test_dataset, inference_signature=inference_signature,
                                        additional_features=additional_features,
                                        logs_dir=logs_dir,
                                        logging_frequency=logging_frequency):

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -243,24 +243,27 @@ class ClassificationModel(RelevanceModel):
             outfile = os.path.join(logs_dir, RelevanceModelConstants.MODEL_PREDICTIONS_CSV_FILE)
             # Delete file if it exists
             self.file_io.rm_file(outfile)
-        predictions_df = self._create_prediction_dataframe(logging_frequency,
-                                                           test_dataset)
-        predictions_ = np.squeeze(self.model.predict(test_dataset)[self.output_name])
-        # Below, avoid doing predictions.tolist() as it explodes the memory
-        # tolist() will create a list of lists, which consumes more memory
-        # than a list on numpy arrays
-        predictions_df[self.output_name] = [x for x in predictions_]
-        if logs_dir:
-            np.set_printoptions(formatter={'all':lambda x: str(x.decode('utf-8')) if isinstance(x, bytes) else str(x)},
-                                linewidth=sys.maxsize,
-                                threshold=sys.maxsize,  # write the full vector in the csv not a truncated version
-                                legacy="1.13")  # enables 1.13 legacy printing mode
-            for col in predictions_df.columns:
-                if isinstance(predictions_df[col].values[0], bytes):
-                    predictions_df[col] = predictions_df[col].str.decode('utf8')
-            predictions_df.to_csv(outfile, mode="w", header=True, index=False)
-            self.logger.info(f"Model predictions written to: {outfile}")
-        return predictions_df
+        for batch_idx, (batch, label) in enumerate(test_dataset.prefetch(tf.data.experimental.AUTOTUNE)):
+            print(f"Processing predictions : Batch {batch_idx}")
+            predictions_batch = self.model.predict(batch)
+            batch_df = self._create_prediction_dataframe(logging_frequency, (batch,label))
+            batch_df[self.output_name] = [x for x in np.squeeze(predictions_batch[self.output_name])]
+            tf.keras.backend.clear_session()
+
+            # Below, avoid doing predictions.tolist() as it explodes the memory
+            # tolist() will create a list of lists, which consumes more memory
+            # than a list on numpy arrays
+            if logs_dir:
+                np.set_printoptions(formatter={'all':lambda x: str(x.decode('utf-8')) if isinstance(x, bytes) else str(x)},
+                                   linewidth=sys.maxsize,
+                                   threshold=sys.maxsize,  # write the full vector in the csv not a truncated version
+                                   legacy="1.13")  # enables 1.13 legacy printing mode
+                for col in batch_df.columns:
+                    if isinstance(batch_df[col].values[0], bytes):
+                        batch_df[col] = batch_df[col].str.decode('utf8')
+                batch_df.to_csv(outfile, mode="a", header=batch_idx==0, index=False)
+        self.logger.info(f"Model predictions written to: {outfile}")
+        return pd.read_csv(outfile)
 
     def _create_prediction_dataframe(self, logging_frequency, test_dataset):
         """
@@ -273,21 +276,13 @@ class ClassificationModel(RelevanceModel):
         features_to_log = [f.get("node_name", f["name"]) for f in
                            self.feature_config.get_features_to_log()] + [label_name]
         features_to_log = set(features_to_log)
-        for batch_count, (x, y) in enumerate(test_dataset.take(-1)):  # returns (x, y) tuples
-            if batch_count:
-                for key in x.keys():
-                    if key in features_to_log:  # only log if necessary
-                        # Here I am appending, np.vstack or other numpy tricks will be slow
-                        # as they create new arrays (a np.array require contiguous memory)
-                        predictions[key].append(np.squeeze(x[key].numpy()))
-                predictions[label_name].append(np.squeeze(y.numpy()))
-            else:  # we initialize the {key: list()} in the 1st batch
-                for key in x.keys():
-                    if key in features_to_log:
-                        predictions[key] = [np.squeeze(x[key].numpy())]
-                predictions[label_name] = [np.squeeze(y.numpy())]
-            if batch_count % logging_frequency == 0:
-                self.logger.info(f"Finished evaluating {batch_count} batches")
+        features, labels = test_dataset
+        for key in features.keys():
+            if key in features_to_log:  # only log if necessary
+               # Here I am appending, np.vstack or other numpy tricks will be slow
+               # as they create new arrays (a np.array require contiguous memory)
+               predictions[key] = [np.squeeze(features[key].numpy())]
+        predictions[label_name] = [np.squeeze(labels.numpy())]
         # This is a memory bottleneck; we bring everything in memory
         for key, val in predictions.items():
             # we want to create np.arrays that contain the full data here.
@@ -297,4 +292,5 @@ class ClassificationModel(RelevanceModel):
                 val)
         predictions_df = pd.DataFrame({key: val if len(val.shape) == 1 else [inner for inner in val]
                                        for key, val in predictions.items()})
+
         return predictions_df

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -111,15 +111,19 @@ class ClassificationModel(RelevanceModel):
                                         additional_features=additional_features,
                                         logs_dir=logs_dir,
                                         logging_frequency=logging_frequency):
+                print("prediction size", len(predictions))
                 for metric in self.model.metrics:
                     global_metrics.append(
                         self.calculate_metric_on_batch(metric, predictions, batch_size))
-                    self.logger.info(f"Global metric {metric.name} completed."
+                    #self.logger.info(f"Global metric {metric.name} completed."
+                    #                 f" Score: {global_metrics[-1]['value']}")
+                    print(f"Global metric {metric.name} completed."
                                      f" Score: {global_metrics[-1]['value']}")
     
                     for group_ in group_metrics_keys:  # Calculate metrics for group metrics
+                        print("group name", group_['name'])
                         for name, group in predictions.groupby(group_['name']):
-                            self.logger.info(f"Per feature metric {metric.name}."
+                            print(f"Per feature metric {metric.name}."
                                              f" Feature: {group_['name']}, value: {name}")
                             if group.shape[0] >= group_metrics_min_queries:
                                 grouped_metrics.append(self.calculate_metric_on_batch(metric,

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -1,5 +1,6 @@
 import ast
 import os
+import re
 import sys
 from typing import Optional
 
@@ -175,7 +176,7 @@ class ClassificationModel(RelevanceModel):
             return np.array([])
             
 
-    def calculate_metric_on_batch(self, metric, predictions, batch_size, group_name=None, group_key=None):
+    def _calculate_metric_on_batch(self, metric, predictions, batch_size, group_name=None, group_key=None):
         """
         Given a metric and a dataframe with `predictions`, it iterates the dataframe in
         using `batch_size` and updates the metric. Once the dataframe is fully iterated,
@@ -207,10 +208,10 @@ class ClassificationModel(RelevanceModel):
 
         # Convert string arrays to numerical arrays if necessary
         if isinstance(predictions[label_name].iloc[0], str):
-            predictions[label_name] = predictions[label_name].apply(lambda x: convert_string_to_array(x))
+            predictions[label_name] = predictions[label_name].apply(lambda x: self._convert_string_to_array(x))
         
         if isinstance(predictions[output_name].iloc[0], str):
-            predictions[output_name] = predictions[output_name].apply(lambda x: convert_string_to_array(x))
+            predictions[output_name] = predictions[output_name].apply(lambda x: self._convert_string_to_array(x))
 
         
         metric.reset_states()

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -222,6 +222,7 @@ class ClassificationModel(RelevanceModel):
             additional_features: dict = {},
             logs_dir: Optional[str] = None,
             logging_frequency: int = 25,
+            batch_size: int = 32
     ):
         """
         Predict the scores on the test dataset using the trained model
@@ -241,6 +242,8 @@ class ClassificationModel(RelevanceModel):
             Path to directory to save logs
         logging_frequency : int
             Value representing how often(in batches) to log status
+        batch_size: int
+            Batch size of predictions
 
         Returns
         -------
@@ -253,7 +256,7 @@ class ClassificationModel(RelevanceModel):
             # Delete file if it exists
             self.file_io.rm_file(outfile)
             
-        for batch_idx, (batch, label) in enumerate(test_dataset.prefetch(tf.data.experimental.AUTOTUNE)):
+        for batch_idx, (batch, label) in enumerate(test_dataset.batch(batch_size).prefetch(tf.data.experimental.AUTOTUNE)):
             if batch_idx % logging_frequency == 0: print(f"Processing predictions : Batch {batch_idx}")
             predictions_batch = self.model.predict(batch)
             batch_df = self._create_prediction_dataframe(logging_frequency, (batch,label))

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -106,33 +106,30 @@ class ClassificationModel(RelevanceModel):
             '''
             batch_size = test_dataset._input_dataset._batch_size.numpy()  # Hacky way to get batch_size
             # Letting metrics in the outer loop to avoid tracing
-            all_predictions = []  # Accumulate all batches in memory
-            for predictions in self.predict(test_dataset, 
+            predictions = pd.concat(self.predict(test_dataset, 
                                         inference_signature=inference_signature,
                                         additional_features=additional_features,
                                         logs_dir=logs_dir,
-                                        logging_frequency=logging_frequency):
-                all_predictions.append(predictions)  # Accumulate batches
-            full_predictions_df = pd.concat(all_predictions)
+                                        logging_frequency=logging_frequency), ignore_index=True)
 
             # Calculate global metrics
             for metric in self.model.metrics:
                 global_metrics.append(
-                    self.calculate_metric_on_batch(metric, full_predictions_df, batch_size))
+                    self.calculate_metric_on_batch(metric, predictions, batch_size))
                 self.logger.info(f"Global metric {metric.name} completed."
                                  f" Score: {global_metrics[-1]['value']}")
             
-            # Calculate group-wise metrics
-            for group_ in group_metrics_keys:  # Calculate metrics for group metrics
-                for name, group in full_predictions_df.groupby(group_['name']):
-                    self.logger.info(f"Per feature metric {metric.name}."
-                                     f" Feature: {group_['name']}, value: {name}")
-                    if group.shape[0] >= group_metrics_min_queries:
-                        grouped_metrics.append(self.calculate_metric_on_batch(metric,
-                                                                              group,
-                                                                              batch_size,
-                                                                              group_['name'],
-                                                                              name))
+                # Calculate group-wise metrics
+                for group_ in group_metrics_keys:  # Calculate metrics for group metrics
+                    for name, group in predictions.groupby(group_['name']):
+                        self.logger.info(f"Per feature metric {metric.name}."
+                                         f" Feature: {group_['name']}, value: {name}")
+                        if group.shape[0] >= group_metrics_min_queries:
+                            grouped_metrics.append(self.calculate_metric_on_batch(metric,
+                                                                                  group,
+                                                                                  batch_size,
+                                                                                  group_['name'],
+                                                                                  name))
             global_metrics = pd.DataFrame(global_metrics)
             grouped_metrics = pd.DataFrame(grouped_metrics).sort_values(by='size')
             if logs_dir:

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -196,6 +196,8 @@ class ClassificationModel(RelevanceModel):
         for chunk in self.get_chunks_from_df(predictions, batch_size):
             y_true = tf.constant(chunk[label_name].values.tolist(), dtype=tf.float32)
             y_pred = tf.constant(chunk[output_name].values.tolist(), dtype=tf.float32)
+
+            print(f"y_true shape: {y_true.shape}, y_pred shape: {y_pred.shape}")
         
             # Ensure y_pred is 2D
             if len(y_pred.shape) == 1:

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -165,7 +165,7 @@ class ClassificationModel(RelevanceModel):
         for pos in range(0, len(dataframe), size):
             yield dataframe.iloc[pos:pos + size]
 
-    def convert_string_to_array(s):
+    def _convert_string_to_array(s):
         try:
             # Add commas between numbers to make it a valid Python list
             s_fixed = re.sub(r"\s+", ",", s.strip())
@@ -176,7 +176,7 @@ class ClassificationModel(RelevanceModel):
             return np.array([])
             
 
-    def _calculate_metric_on_batch(self, metric, predictions, batch_size, group_name=None, group_key=None):
+    def calculate_metric_on_batch(self, metric, predictions, batch_size, group_name=None, group_key=None):
         """
         Given a metric and a dataframe with `predictions`, it iterates the dataframe in
         using `batch_size` and updates the metric. Once the dataframe is fully iterated,

--- a/python/ml4ir/applications/classification/model/classification_model.py
+++ b/python/ml4ir/applications/classification/model/classification_model.py
@@ -106,6 +106,7 @@ class ClassificationModel(RelevanceModel):
             '''
             batch_size = test_dataset._input_dataset._batch_size.numpy()  # Hacky way to get batch_size
             # Letting metrics in the outer loop to avoid tracing
+            all_predictions = []  # Accumulate all batches in memory
             for predictions in self.predict(test_dataset, 
                                         inference_signature=inference_signature,
                                         additional_features=additional_features,

--- a/python/ml4ir/applications/classification/tests/test_classification_model.py
+++ b/python/ml4ir/applications/classification/tests/test_classification_model.py
@@ -35,7 +35,7 @@ class ClassificationModelTest(ClassificationTestBase):
 
         # Assert we predict for all the items
         expected_size_predictions = 200  # the same with data in test
-        self.assertTrue(self.predictions.shape[0] == expected_size_predictions)
+        self.assertTrue(pd.concat(self.predictions, ignore_index=True).shape[0] == expected_size_predictions)
 
     def test_group_metrics_df(self):
         """

--- a/python/ml4ir/applications/classification/tests/test_classification_model.py
+++ b/python/ml4ir/applications/classification/tests/test_classification_model.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import pandas as pd
 from ml4ir.applications.classification.tests.test_base import ClassificationTestBase
 
 

--- a/python/ml4ir/applications/classification/tests/test_classification_serving.py
+++ b/python/ml4ir/applications/classification/tests/test_classification_serving.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+import pandas as pd
 import tensorflow as tf
 from tensorflow.keras import models as kmodels
 

--- a/python/ml4ir/applications/classification/tests/test_classification_serving.py
+++ b/python/ml4ir/applications/classification/tests/test_classification_serving.py
@@ -60,7 +60,7 @@ class ClassificationServingTest(ClassificationTestBase):
         parsed_dataset_batch = parsed_relevance_dataset.test.take(1)
 
         # Use the loaded serving signatures for inference
-        model_predictions = classification_model.predict(parsed_dataset_batch)[
+        model_predictions = pd.concat(classification_model.predict(parsed_dataset_batch), ignore_index=True)[
             self.args.output_name
         ].values
         default_signature_predictions = default_signature(**parsed_sequence_examples)[

--- a/python/ml4ir/applications/ranking/model/ranking_model.py
+++ b/python/ml4ir/applications/ranking/model/ranking_model.py
@@ -60,13 +60,14 @@ class RankingModel(RelevanceModel):
         """
         additional_features[metrics_helper.RankingConstants.NEW_RANK] = prediction_helper.convert_score_to_rank
 
-        return super().predict(
+        for prediction_batch in super().predict(
             test_dataset=test_dataset,
             inference_signature=inference_signature,
             additional_features=additional_features,
             logs_dir=logs_dir,
-            logging_frequency=logging_frequency,
-        )
+            logging_frequency=logging_frequency):
+                yield prediction_batch
+                
 
     def evaluate(
         self,

--- a/python/ml4ir/applications/ranking/model/ranking_model.py
+++ b/python/ml4ir/applications/ranking/model/ranking_model.py
@@ -60,6 +60,7 @@ class RankingModel(RelevanceModel):
         """
         additional_features[metrics_helper.RankingConstants.NEW_RANK] = prediction_helper.convert_score_to_rank
 
+        # Iterate through all the predictions returned by predict function and yield them
         for prediction_batch in super().predict(
             test_dataset=test_dataset,
             inference_signature=inference_signature,

--- a/python/ml4ir/applications/ranking/tests/test_serving.py
+++ b/python/ml4ir/applications/ranking/tests/test_serving.py
@@ -88,7 +88,7 @@ class RankingModelTest(RankingTestBase):
         parsed_dataset_batch = parsed_dataset.test.take(1)
 
         # Use the loaded serving signatures for inference
-        model_predictions = pd.concat(model.predict(parsed_dataset_batch), ignore_indexes=True)[self.args.output_name].values
+        model_predictions = pd.concat(model.predict(parsed_dataset_batch), ignore_index=True)[self.args.output_name].values
         default_signature_predictions = default_signature(**parsed_sequence_examples)[
             self.args.output_name
         ]

--- a/python/ml4ir/applications/ranking/tests/test_serving.py
+++ b/python/ml4ir/applications/ranking/tests/test_serving.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+import pandas as pd
 import tensorflow as tf
 from tensorflow.keras import models as kmodels
 
@@ -87,7 +88,7 @@ class RankingModelTest(RankingTestBase):
         parsed_dataset_batch = parsed_dataset.test.take(1)
 
         # Use the loaded serving signatures for inference
-        model_predictions = model.predict(parsed_dataset_batch)[self.args.output_name].values
+        model_predictions = pd.concat(model.predict(parsed_dataset_batch), ignore_indexes=True)[self.args.output_name].values
         default_signature_predictions = default_signature(**parsed_sequence_examples)[
             self.args.output_name
         ]

--- a/python/ml4ir/base/model/relevance_model.py
+++ b/python/ml4ir/base/model/relevance_model.py
@@ -558,20 +558,13 @@ class RelevanceModel:
                     # If writing first time, write headers to CSV file
                     predictions_df.to_csv(outfile, mode="w", header=True, index=False)
 
-            else:
-                predictions_df_list.append(predictions_df)
-
             batch_count += 1
             if batch_count % logging_frequency == 0:
                 self.logger.info("Finished predicting scores for {} batches".format(batch_count))
-
-        predictions_df = None
+            yield predictions_df
+            
         if logs_dir:
             self.logger.info("Model predictions written to -> {}".format(outfile))
-        else:
-            predictions_df = pd.concat(predictions_df_list)
-
-        return predictions_df
 
     def evaluate(
             self,

--- a/python/ml4ir/base/pipeline.py
+++ b/python/ml4ir/base/pipeline.py
@@ -8,6 +8,7 @@ import time
 import ast
 from argparse import Namespace
 from logging import Logger
+from collections import deque
 import pathlib
 from typing import List, Union, Type, Optional
 import copy
@@ -607,15 +608,14 @@ class RelevancePipeline(object):
                 ExecutionModeKey.INFERENCE_EVALUATE_RESAVE,
                 ExecutionModeKey.INFERENCE_RESAVE,
             }:
-
                 # Predict relevance scores
-                relevance_model.predict(
+                deque(relevance_model.predict(
                     test_dataset=relevance_dataset.test,
                     inference_signature=self.args.inference_signature,
                     additional_features={},
                     logs_dir=self.logs_dir_local,
                     logging_frequency=self.args.logging_frequency,
-                )
+                ), maxlen=0)
 
             # Write experiment details to experiment tracking dictionary
             # Add command line script arguments

--- a/python/ml4ir/base/pipeline.py
+++ b/python/ml4ir/base/pipeline.py
@@ -609,6 +609,8 @@ class RelevancePipeline(object):
                 ExecutionModeKey.INFERENCE_RESAVE,
             }:
                 # Predict relevance scores
+                # deque will exhaust/drain all batches returned by predict function
+                # this way predict function will run on whole test_dataset
                 deque(relevance_model.predict(
                     test_dataset=relevance_dataset.test,
                     inference_signature=self.args.inference_signature,


### PR DESCRIPTION
**Issue**
In relevance model pipeline when we try to Inference we use predict function. In classification_model this predict function try to perform inference on whole data at once which often leads to OOM errors.

**Fix**
In this PR, I provide a fix for this
- Predict function of classification_model is now a generator, means it will operate on a batch of test dataset and yield prediction and then again operate on next batch of test dataset.
- This predict function is also used by ranking pipeline (relevance_model). However predict function in ranking pipeline does not evaluate whole data at once but work in batches and then combine all predictions into one dataframe. But both predict function should behave same, so i updated predict function in relevance model as well to yield batches.
- I am not creating new test cases for predict function as those test cases already exists. But I modified test cases for predict function to make it work with the changes made to this function.